### PR TITLE
Windows App Icon

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ project(SQLiteQueryAnalyzer VERSION 1.0 LANGUAGES C CXX)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOUIC ON)
+set(app_icon_resource_windows "${CMAKE_CURRENT_SOURCE_DIR}/icon.rc")
 
 find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Sql)
@@ -20,6 +21,7 @@ qt_add_executable(SQLiteQueryAnalyzer WIN32 MACOSX_BUNDLE
     main.cpp
     mainwindow.cpp mainwindow.h mainwindow.ui
     recentfiles.cpp recentfiles.h
+    ${app_icon_resource_windows}
 )
 target_link_libraries(SQLiteQueryAnalyzer PRIVATE
     Qt::Core

--- a/src/SQLiteAnalyzer.pro
+++ b/src/SQLiteAnalyzer.pro
@@ -12,6 +12,7 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 TARGET = "SQLiteQueryAnalyzer"
 TEMPLATE = app
 VERSION = 1.0.0.0
+RC_ICONS = icon.ico
 
 SOURCES += main.cpp\
         mainwindow.cpp \

--- a/src/icon.rc
+++ b/src/icon.rc
@@ -1,0 +1,5 @@
+#include <windows.h>
+
+// Icon
+IDI_ICON1               ICON                    "icon.ico"
+


### PR DESCRIPTION
This pull request includes changes to add an application icon to the `SQLiteQueryAnalyzer` project for Windows. The most important changes are listed below:

### Addition of application icon:

* [`src/CMakeLists.txt`](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4R6): Added a new setting for `app_icon_resource_windows` to include the icon resource file (`[src/CMakeLists.txtR6](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4R6)`).
* [`src/CMakeLists.txt`](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4R24): Updated the `qt_add_executable` command to include the `app_icon_resource_windows` variable (`[src/CMakeLists.txtR24](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4R24)`).
* [`src/SQLiteAnalyzer.pro`](diffhunk://#diff-7973f19edc5de346c77252bd40cdb33bcaf973b7033b89a4fc8eb8ae8c4cd75cR15): Added a new line to include the `icon.ico` file in the resource compiler (`[src/SQLiteAnalyzer.proR15](diffhunk://#diff-7973f19edc5de346c77252bd40cdb33bcaf973b7033b89a4fc8eb8ae8c4cd75cR15)`).
* [`src/icon.rc`](diffhunk://#diff-30c7efad3930e3f35c00192e1008b5f3fb8c14cf55ffae7d641d8b0d17515b2bR1-R5): Created a new resource file to define the application icon (`[src/icon.rcR1-R5](diffhunk://#diff-30c7efad3930e3f35c00192e1008b5f3fb8c14cf55ffae7d641d8b0d17515b2bR1-R5)`).