### PR TITLE
Set Application Version and update About dialog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Update Version in code
+      shell: pwsh
+      run: |
+        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = .*', '#define VERSION = ${{ env.VERSION }}'
+        $version | Set-Content -Path src/main.cpp
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
@@ -27,6 +32,11 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Update Version in code
+      shell: pwsh
+      run: |
+        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = .*', '#define VERSION = ${{ env.VERSION }}'
+        $version | Set-Content -Path src/main.cpp
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
@@ -60,6 +70,12 @@ jobs:
         run: |
           $version = (Get-Content -Path src/setup.iss -Raw) -replace 'AppVersion= .*', 'AppVersion = ${{ env.VERSION }}'
           $version | Set-Content -Path src/setup.iss
+
+      - name: Update Version in code
+        shell: pwsh
+        run: |
+          $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = .*', '#define VERSION = ${{ env.VERSION }}'
+          $version | Set-Content -Path src/main.cpp
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Update Version in code
       shell: pwsh
       run: |
-        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION "1.0.0"', '#define VERSION = "${{ env.VERSION }}"'
+        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION "1.0.0"', '#define VERSION "${{ env.VERSION }}"'
         $version | Set-Content -Path src/main.cpp
         cat src/main.cpp
     - name: Install Qt
@@ -36,7 +36,7 @@ jobs:
     - name: Update Version in code
       shell: pwsh
       run: |
-        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION "1.0.0"', '#define VERSION = "${{ env.VERSION }}"'
+        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION "1.0.0"', '#define VERSION "${{ env.VERSION }}"'
         $version | Set-Content -Path src/main.cpp
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
@@ -75,7 +75,7 @@ jobs:
       - name: Update Version in code
         shell: pwsh
         run: |
-          $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION "1.0.0"', '#define VERSION = "${{ env.VERSION }}"'
+          $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION "1.0.0"', '#define VERSION "${{ env.VERSION }}"'
           $version | Set-Content -Path src/main.cpp
 
       - name: Install Qt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Update Version in code
       shell: pwsh
       run: |
-        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = .*', '#define VERSION = ${{ env.VERSION }}'
+        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = 1.0.0', '#define VERSION = ${{ env.VERSION }}'
         $version | Set-Content -Path src/main.cpp
         cat src/main.cpp
     - name: Install Qt
@@ -36,7 +36,7 @@ jobs:
     - name: Update Version in code
       shell: pwsh
       run: |
-        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = .*', '#define VERSION = ${{ env.VERSION }}'
+        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = 1.0.0', '#define VERSION = ${{ env.VERSION }}'
         $version | Set-Content -Path src/main.cpp
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
@@ -63,19 +63,19 @@ jobs:
       - name: Update Version Number (Qt Project)
         shell: pwsh
         run: |
-          $version = (Get-Content -Path src/SQLiteAnalyzer.pro -Raw) -replace 'VERSION = .*', 'VERSION = ${{ env.VERSION }}'
+          $version = (Get-Content -Path src/SQLiteAnalyzer.pro -Raw) -replace 'VERSION = 1.0.0', 'VERSION = ${{ env.VERSION }}'
           $version | Set-Content -Path src/SQLiteAnalyzer.pro
 
       - name: Update Version Number (Inno Setup)
         shell: pwsh
         run: |
-          $version = (Get-Content -Path src/setup.iss -Raw) -replace 'AppVersion= .*', 'AppVersion = ${{ env.VERSION }}'
+          $version = (Get-Content -Path src/setup.iss -Raw) -replace 'AppVersion = 1.0.0', 'AppVersion = ${{ env.VERSION }}'
           $version | Set-Content -Path src/setup.iss
 
       - name: Update Version in code
         shell: pwsh
         run: |
-          $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = .*', '#define VERSION = ${{ env.VERSION }}'
+          $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = 1.0.0', '#define VERSION = ${{ env.VERSION }}'
           $version | Set-Content -Path src/main.cpp
 
       - name: Install Qt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Update Version in code
       shell: pwsh
       run: |
-        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = 1.0.0', '#define VERSION = ${{ env.VERSION }}'
+        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = "1.0.0"', '#define VERSION = "${{ env.VERSION }}"'
         $version | Set-Content -Path src/main.cpp
         cat src/main.cpp
     - name: Install Qt
@@ -36,7 +36,7 @@ jobs:
     - name: Update Version in code
       shell: pwsh
       run: |
-        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = 1.0.0', '#define VERSION = ${{ env.VERSION }}'
+        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = "1.0.0"', '#define VERSION = "${{ env.VERSION }}"'
         $version | Set-Content -Path src/main.cpp
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
@@ -75,7 +75,7 @@ jobs:
       - name: Update Version in code
         shell: pwsh
         run: |
-          $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = 1.0.0', '#define VERSION = ${{ env.VERSION }}'
+          $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = "1.0.0"', '#define VERSION = "${{ env.VERSION }}"'
           $version | Set-Content -Path src/main.cpp
 
       - name: Install Qt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       run: |
         $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = .*', '#define VERSION = ${{ env.VERSION }}'
         $version | Set-Content -Path src/main.cpp
+        cat src/main.cpp
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Update Version in code
       shell: pwsh
       run: |
-        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = "1.0.0"', '#define VERSION = "${{ env.VERSION }}"'
+        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION "1.0.0"', '#define VERSION = "${{ env.VERSION }}"'
         $version | Set-Content -Path src/main.cpp
         cat src/main.cpp
     - name: Install Qt
@@ -36,7 +36,7 @@ jobs:
     - name: Update Version in code
       shell: pwsh
       run: |
-        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = "1.0.0"', '#define VERSION = "${{ env.VERSION }}"'
+        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION "1.0.0"', '#define VERSION = "${{ env.VERSION }}"'
         $version | Set-Content -Path src/main.cpp
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
@@ -75,7 +75,7 @@ jobs:
       - name: Update Version in code
         shell: pwsh
         run: |
-          $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION = "1.0.0"', '#define VERSION = "${{ env.VERSION }}"'
+          $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION "1.0.0"', '#define VERSION = "${{ env.VERSION }}"'
           $version | Set-Content -Path src/main.cpp
 
       - name: Install Qt

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,12 @@
 #include <QApplication>
 #include "mainwindow.h"
 
+#define VERSION "1.0.0"
+
 int main(int argc, char *argv[]) {
     QApplication a(argc, argv);
+    a.setApplicationVersion(VERSION);
+
     MainWindow w;
 
     QStringList args = a.arguments();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -202,6 +202,11 @@ void MainWindow::treeNodeChanged(QTreeWidgetItem *item, int column) {
 }
 
 void MainWindow::about() {
-    QString text = "Database management and query analyzer tool for SQLite";
+    const QString text = "SQLite Query Analyzer\n"
+                         "Copyright (c) Christian Resma Helle 2015\n"
+                         "All rights reserved.\n\n"
+                         "Description:\n"
+                         "A fast and lightweight cross-platform GUI tool "
+                         "for querying and manipulating SQLite databases.";
     QMessageBox::about(this, "About", text);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -203,6 +203,7 @@ void MainWindow::treeNodeChanged(QTreeWidgetItem *item, int column) {
 
 void MainWindow::about() {
     const QString text = "SQLite Query Analyzer\n"
+                         "Version: " + QApplication::applicationVersion() + "\n"
                          "Copyright (c) Christian Resma Helle 2015\n"
                          "All rights reserved.\n\n"
                          "Description:\n"


### PR DESCRIPTION
This pull request includes several changes to the versioning system in the build workflow and updates to the source code to reflect the version number dynamically. The key changes involve updating the version number in various files and displaying it in the application.

### Workflow and Versioning Updates:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R15-R20): Added steps to update the version number in `src/main.cpp` for both Ubuntu and macOS build jobs. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R15-R20) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R36-R40)
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L55-R80): Modified the version update steps to replace the specific version string '1.0.0' with the environment variable `${{ env.VERSION }}` in `src/SQLiteAnalyzer.pro` and `src/setup.iss`.

### Source Code Updates:

* [`src/main.cpp`](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R4-R9): Added a preprocessor definition for `VERSION` and set the application version using `QApplication::setApplicationVersion`.
* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L205-R211): Updated the `about` dialog to include the application version dynamically using `QApplication::applicationVersion()`.