### PR TITLE
Build MacOS Disk Image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,12 +48,15 @@ jobs:
     - name: Make
       run: make
       working-directory: src
+    - name: macdeployqt
+      working-directory: src
+      run: macdeployqt SQLiteQueryAnalyzer.app -dmg
     - name: Publish artifacts
       uses: actions/upload-artifact@v4
       with:
         name: SQLiteQuerAnalyzer_MacOS_v${{ env.VERSION }}
         path: |
-          src/*.app
+          src/*.dmg
 
   windows:
     runs-on:  windows-latest

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ src/cmake-build-debug
 .vscode/settings.json
 src/Artifacts
 .DS_Store
+src/.qt
+src/CMakeFiles
+src/SQLiteQueryAnalyzer_autogen
+*.dmg
+src/cmake_install.cmake
+src/CMakeCache.txt

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 qmake SQLiteAnalyzer.pro
 make
+macdeployqt SQLiteQueryAnalyzer.app -dmg


### PR DESCRIPTION
This pull request includes changes to the build process for the macOS version of the SQLite Query Analyzer. The most important changes involve the addition of the `macdeployqt` command to package the application into a `.dmg` file.

Changes to the build process:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R51-R59): Added a step to run `macdeployqt` to create a `.dmg` file for the macOS build and updated the artifact publishing path to use the `.dmg` file instead of the `.app` file.
* [`src/build.sh`](diffhunk://#diff-02f64ab7fe6df7a34979c489dccf70a9902438ab964f4fe9471534d6b7b74a76R4): Added the `macdeployqt` command to package the SQLite Query Analyzer application into a `.dmg` file after the `make` command.