### PR TITLE
Fix issue with table data not shown

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -184,11 +184,11 @@ void MainWindow::executeQuery() const {
     }
 }
 
-void MainWindow::treeNodeChanged(const QTreeWidgetItem *item) const {
+void MainWindow::treeNodeChanged(QTreeWidgetItem *item) const {
     treeNodeChanged(item, 0);
 }
 
-void MainWindow::treeNodeChanged(const QTreeWidgetItem *item, const int column) const {
+void MainWindow::treeNodeChanged(QTreeWidgetItem *item, const int column) const {
     if (item && item->type() == QTreeWidgetItem::UserType + 1) {
         qDebug("table selected");
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -15,13 +15,13 @@ namespace Ui {
 class MainWindow;
 }
 
-class MainWindow : public QMainWindow
+class MainWindow final : public QMainWindow
 {
     Q_OBJECT
 
 public:
-    explicit MainWindow(QWidget *parent = 0);
-    ~MainWindow();
+    explicit MainWindow(QWidget *parent = nullptr);
+    ~MainWindow() override;
 
     void loadRecentFiles() const;
     void openDatabase(const QString &filename) const;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -31,8 +31,8 @@ public slots:
 
     static void appExit();
     void executeQuery() const;
-    void treeNodeChanged(const QTreeWidgetItem*,int) const;
-    void treeNodeChanged(const QTreeWidgetItem*) const;
+    void treeNodeChanged(QTreeWidgetItem *, int) const;
+    void treeNodeChanged(QTreeWidgetItem *) const;
     void shrink() const;
     void refreshDatabase() const;
     void about();


### PR DESCRIPTION
This pull request includes several changes to the `MainWindow` class in the `src/mainwindow.cpp` and `src/mainwindow.h` files to improve code consistency and modernize the codebase. The most important changes include removing unnecessary `const` qualifiers, marking the `MainWindow` class as `final`, and updating pointer initialization.

Code consistency improvements:

* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L187-R191): Removed unnecessary `const` qualifiers from the `treeNodeChanged` method parameters.

Modernization of codebase:

* [`src/mainwindow.h`](diffhunk://#diff-043d32442474a7903890f612e2ffb16d87f94a94a6814ad6cbf2a57e7372942dL18-R24): Marked the `MainWindow` class as `final` to prevent further inheritance.
* [`src/mainwindow.h`](diffhunk://#diff-043d32442474a7903890f612e2ffb16d87f94a94a6814ad6cbf2a57e7372942dL18-R24): Updated the `MainWindow` constructor to use `nullptr` instead of `0` for the parent widget parameter and marked the destructor with the `override` keyword.
* [`src/mainwindow.h`](diffhunk://#diff-043d32442474a7903890f612e2ffb16d87f94a94a6814ad6cbf2a57e7372942dL34-R35): Removed unnecessary `const` qualifiers from the `treeNodeChanged` method parameters.