### PR TITLE
Add build instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,79 @@ Here are some screenshots of SQLiteQuery in action:
 ![Dark Mode Select query](images/dark-query-select.png)
 ![Dark Mode Table data editing](images/dark-table-data.png)
 
+## Building
+
+### Prerequisites
+
+- CMake 3.16 or later - Install from [official website](https://cmake.org/download/)
+- Qt 6.8.2 - Install from [official website](https://www.qt.io/download-qt-installer-oss)
+- Git
+
+### Clone the repository
+
+```sh
+git clone https://github.com/christianhelle/sqlitequery.git
+cd sqlitequery
+```
+
+### Building on Linux
+
+Install CMAke and Qt6
+
+```sh
+sudo apt-get update
+sudo apt-get install -y cmake qt6-base-dev
+```
+
+Build project
+
+```sh
+cd src
+cmake .
+cmake --build . --config Release
+```
+
+### Building on MacOS
+
+Install CMAke and Qt6
+
+```sh
+brew update
+brew install cmake
+brew install qt@6
+```
+
+Build project
+
+```sh
+cd src
+cmake .
+cmake --build . --config Release
+```
+
+Build MacOS disk image (Optional)
+
+```sh
+macdeployqt SQLiteQueryAnalyzer.app -dmg
+```
+
+### Building on Windows
+
+Build the project (These instructions assumes that Qt root folder is C:\Qt)
+
+```pwsh
+cd src
+cmake . -DCMAKE_PREFIX_PATH=C:/Qt/6.8.2/msvc2022_64 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /permissive-" -B build
+cmake --build build --config Release
+C:\Qt\6.8.2\msvc2022_64\bin\windeployqt.exe .\build\Release\SQLiteQueryAnalyzer.exe
+```
+
+Build the installer project using Inno Setup (Optional)
+
+```pwsh
+../deps/innosetup/ISCC.exe setup.iss
+```
+
 ## Contributing
 
 We welcome contributions to SQLite Query Analyzer! If you have any ideas, suggestions, or bug reports, please open an issue or submit a pull request on GitHub.

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -1,9 +1,4 @@
-#Remove-Item .\release -Recurse -Force
-#qmake SQLiteAnalyzer.pro -config release
 cmake . -DCMAKE_PREFIX_PATH=C:/Qt/6.8.2/msvc2022_64 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /permissive-" -B build
 cmake --build build --config Release
-# mingw32-make -j32
-# mkdir .\release\bin
-# Move-Item .\release\SQLiteQueryAnalyzer.exe .\release\bin
 C:\Qt\6.8.2\msvc2022_64\bin\windeployqt.exe .\build\Release\SQLiteQueryAnalyzer.exe
 ../deps/innosetup/ISCC.exe setup.iss

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-qmake SQLiteAnalyzer.pro
-make
+cmake .
+cmake --build . --config Release
 macdeployqt SQLiteQueryAnalyzer.app -dmg


### PR DESCRIPTION
This pull request includes updates to the build instructions and scripts for the SQLiteQuery project. The changes add detailed build instructions for different operating systems and update the build scripts to use CMake instead of qmake.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R103): Added detailed build instructions for Linux, MacOS, and Windows, including prerequisites and step-by-step commands.

### Build script updates:

* [`src/build.ps1`](diffhunk://#diff-0a79f8128018ad45b36df274b955057e8200498bcc31a1825bca64b6a326eac1L1-L7): Updated the PowerShell build script to use CMake for building the project and removed commented-out qmake commands.
* [`src/build.sh`](diffhunk://#diff-02f64ab7fe6df7a34979c489dccf70a9902438ab964f4fe9471534d6b7b74a76L2-R3): Updated the Bash build script to use CMake for building the project and removed the qmake command.