### PR TITLE
Automatically clean-up recents file list

### DIFF
--- a/src/recentfiles.cpp
+++ b/src/recentfiles.cpp
@@ -55,8 +55,9 @@ QStringList RecentFiles::getList() {
 
     if (QTextStream in(file.get()); in.seek(0)) {
         while (!in.atEnd()) {
-            if (QString line = in.readLine(); !files.contains(line, Qt::CaseInsensitive))
+            if (QString line = in.readLine(); !files.contains(line, Qt::CaseInsensitive) && QFile::exists(line)) {
                 files.append(line);
+            }
         }
     }
 


### PR DESCRIPTION
This pull request includes changes to the `RecentFiles` class in `src/recentfiles.cpp` to improve file handling and validation. The changes focus on ensuring that only valid and unique file paths are added to the recent files list.

Improvements to file handling and validation:

* [`src/recentfiles.cpp`](diffhunk://#diff-fe064aa60c8042628e7a0aea197d629e8a7236915c004265d3b5dcc6c8f69e30L20-R40): Modified the `add` method to check if the file exists before adding it to the recent files list and to avoid duplicate entries by using a local `files` list. Added a debug message for duplicate entries and ensured the file is opened with the `QIODevice::Truncate` flag to overwrite existing content.
* [`src/recentfiles.cpp`](diffhunk://#diff-fe064aa60c8042628e7a0aea197d629e8a7236915c004265d3b5dcc6c8f69e30L58-R65): Updated the `getList` method to sanitize file paths and check for file existence before adding them to the list, ensuring only valid and existing files are included.