### PR TITLE
Reset state when switching databases

### DIFF
--- a/src/dbquery.h
+++ b/src/dbquery.h
@@ -12,14 +12,14 @@ public:
 
     bool execute(const QStringList &, QStringList *) const;
 
+    void clearResults() const;
+
 private:
     QWidget *widget;
     QScrollArea *scrollArea;
     QWidget *container;
     QList<QTableView *> *tableResults;
     Database *database;
-
-    void clearResults() const;
 };
 
 #endif // DBQUERY_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -210,7 +210,7 @@ void MainWindow::treeNodeChanged(QTreeWidgetItem *item, const int column) const 
         }
 
         if (ui->tableView->model() != Q_NULLPTR)
-            delete ui->tableView->model();
+            std::make_unique<QSqlTableModel>(ui->tableView->model());
 
         auto *model = new QSqlTableModel(nullptr, this->database->getDatabase());
         model->setTable(item->text(column));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -212,7 +212,9 @@ void MainWindow::treeNodeChanged(QTreeWidgetItem *item, const int column) const 
         if (ui->tableView->model() != Q_NULLPTR)
             std::make_unique<QSqlTableModel>(ui->tableView->model());
 
-        auto *model = new QSqlTableModel(nullptr, this->database->getDatabase());
+        // The model is no longer alive after the unique pointer destroys it...
+        // ReSharper disable once CppDFAMemoryLeak
+        const auto model = new QSqlTableModel(nullptr, this->database->getDatabase());
         model->setTable(item->text(column));
         model->setEditStrategy(QSqlTableModel::OnFieldChange);
         model->select();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -118,6 +118,11 @@ void MainWindow::openDatabase(const QString &filename) const {
     ui->queryResultMessagesTextEdit->clear();
     ui->tabWidget->setCurrentIndex(0);
     ui->textEdit->clear();
+
+    if (ui->tableView->model() != Q_NULLPTR) {
+        std::make_unique<QSqlTableModel>(ui->tableView->model());
+        ui->tableView->setModel(Q_NULLPTR);
+    }
 }
 
 void MainWindow::openExistingFile() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -113,6 +113,11 @@ void MainWindow::openDatabase(const QString &filename) const {
 
     this->analyzeDatabase();
     RecentFiles::add(filename);
+
+    this->query->clearResults();
+    ui->queryResultMessagesTextEdit->clear();
+    ui->tabWidget->setCurrentIndex(0);
+    ui->textEdit->clear();
 }
 
 void MainWindow::openExistingFile() {


### PR DESCRIPTION
This pull request includes changes to the `src/dbquery.h` and `src/mainwindow.cpp` files to improve memory management and ensure proper clearing of results when opening a new database.

Improvements to memory management:

* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R116-R125): Replaced direct deletion of `QSqlTableModel` instances with `std::make_unique` to ensure proper memory management when clearing the table view model. [[1]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R116-R125) [[2]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L203-R217)

Enhancements to result clearing:

* [`src/dbquery.h`](diffhunk://#diff-400e6236058214131c263b3add05a7cfa48e36e99d5fe3569a5454915ce8ec96R15-L22): Moved the `clearResults` method to the public section of the `DbQuery` class to ensure it can be called from other parts of the code.
* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R116-R125): Added calls to `clearResults` and other UI clearing methods when opening a new database to ensure the UI is properly reset.