### PR TITLE
Add primary key and default value details to column tree

### DIFF
--- a/src/dbtree.cpp
+++ b/src/dbtree.cpp
@@ -77,6 +77,14 @@ void DbTree::populateTree(const DatabaseInfo& info) const {
             const auto colNotNull = new QTreeWidgetItem(colName);
             colNotNull->setText(0, QString("Allow Null: ").append(!col.notNull ? "True" : "False"));
             this->treeNodes->prepend(colNotNull);
+
+            const auto colPrimaryKey = new QTreeWidgetItem(colName);
+            colPrimaryKey->setText(0, QString("Is Primary Key: ").append(col.primaryKey ? "True" : "False"));
+            this->treeNodes->prepend(colPrimaryKey);
+
+            const auto defaultValue = new QTreeWidgetItem(colName);
+            defaultValue->setText(0, QString("Default Value: ").append(col.defaultValue));
+            this->treeNodes->prepend(defaultValue);
         }
     }
 


### PR DESCRIPTION
This pull request includes several enhancements to the `DbTree::populateTree` method in the `src/dbtree.cpp` file. These changes add more detailed information about database columns to the tree nodes.

Enhancements to database column information:

* Added a new tree node to indicate whether a column is a primary key.
* Added a new tree node to display the default value of a column.