### PR TITLE
Add Build and SonarCloud badges to README

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,29 @@
+name: Linux
+
+on:
+  push:
+
+env:
+  VERSION: '0.1.${{ github.run_number }}'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Update Version in code
+      shell: pwsh
+      run: |
+        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION "1.0.0"', '#define VERSION "${{ env.VERSION }}"'
+        $version | Set-Content -Path src/main.cpp
+        cat src/main.cpp
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.8.2'
+    - name: QMake
+      run: qmake
+      working-directory: src
+    - name: Make
+      run: make
+      working-directory: src

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,37 @@
+name: MacOS
+
+on:
+  push:
+
+env:
+  VERSION: '0.1.${{ github.run_number }}'
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Update Version in code
+      shell: pwsh
+      run: |
+        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION "1.0.0"', '#define VERSION "${{ env.VERSION }}"'
+        $version | Set-Content -Path src/main.cpp
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.8.2'
+    - name: QMake
+      run: qmake
+      working-directory: src
+    - name: Make
+      run: make
+      working-directory: src
+    - name: macdeployqt
+      working-directory: src
+      run: macdeployqt SQLiteQueryAnalyzer.app -dmg
+    - name: Publish artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: SQLiteQuerAnalyzer_MacOS_v${{ env.VERSION }}
+        path: |
+          src/*.dmg

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name: build
+name: Windows
 
 on:
   push:
@@ -7,58 +7,7 @@ env:
   VERSION: '0.1.${{ github.run_number }}'
 
 jobs:
-
-  ubuntu:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Update Version in code
-      shell: pwsh
-      run: |
-        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION "1.0.0"', '#define VERSION "${{ env.VERSION }}"'
-        $version | Set-Content -Path src/main.cpp
-        cat src/main.cpp
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v4
-      with:
-        version: '6.8.2'
-    - name: QMake
-      run: qmake
-      working-directory: src
-    - name: Make
-      run: make
-      working-directory: src
-
-  mac:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Update Version in code
-      shell: pwsh
-      run: |
-        $version = (Get-Content -Path src/main.cpp -Raw) -replace '#define VERSION "1.0.0"', '#define VERSION "${{ env.VERSION }}"'
-        $version | Set-Content -Path src/main.cpp
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v4
-      with:
-        version: '6.8.2'
-    - name: QMake
-      run: qmake
-      working-directory: src
-    - name: Make
-      run: make
-      working-directory: src
-    - name: macdeployqt
-      working-directory: src
-      run: macdeployqt SQLiteQueryAnalyzer.app -dmg
-    - name: Publish artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: SQLiteQuerAnalyzer_MacOS_v${{ env.VERSION }}
-        path: |
-          src/*.dmg
-
-  windows:
+  build:
     runs-on:  windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 [![build](https://github.com/christianhelle/sqlitequery/actions/workflows/build.yml/badge.svg)](https://github.com/christianhelle/sqlitequery/actions/workflows/build.yml)
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=christianhelle_sqlitequery&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=christianhelle_sqlitequery)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=christianhelle_sqlitequery&metric=bugs)](https://sonarcloud.io/summary/new_code?id=christianhelle_sqlitequery)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=christianhelle_sqlitequery&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=christianhelle_sqlitequery)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=christianhelle_sqlitequery&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=christianhelle_sqlitequery)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=christianhelle_sqlitequery&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=christianhelle_sqlitequery)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=christianhelle_sqlitequery&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=christianhelle_sqlitequery)
+
 # SQLite Query Analyzer
 
 SQLite Query Analyzer is a lightweight and efficient desktop utility designed to simplify the process of managing SQLite databases.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-[![build](https://github.com/christianhelle/sqlitequery/actions/workflows/build.yml/badge.svg)](https://github.com/christianhelle/sqlitequery/actions/workflows/build.yml)
+[![Linux](https://github.com/christianhelle/sqlitequery/actions/workflows/linux.yml/badge.svg)](https://github.com/christianhelle/sqlitequery/actions/workflows/linux.yml)
+[![MacOS](https://github.com/christianhelle/sqlitequery/actions/workflows/macos.yml/badge.svg)](https://github.com/christianhelle/sqlitequery/actions/workflows/macos.yml)
+[![Windows](https://github.com/christianhelle/sqlitequery/actions/workflows/windows.yml/badge.svg)](https://github.com/christianhelle/sqlitequery/actions/workflows/windows.yml)
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=christianhelle_sqlitequery&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=christianhelle_sqlitequery)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=christianhelle_sqlitequery&metric=bugs)](https://sonarcloud.io/summary/new_code?id=christianhelle_sqlitequery)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=christianhelle_sqlitequery&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=christianhelle_sqlitequery)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=christianhelle_sqlitequery&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=christianhelle_sqlitequery)
+
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=christianhelle_sqlitequery&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=christianhelle_sqlitequery)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=christianhelle_sqlitequery&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=christianhelle_sqlitequery)
 


### PR DESCRIPTION
This pull request introduces new GitHub Actions workflows for Linux and macOS, updates the existing Windows workflow, and enhances the README file with additional badges.

### New GitHub Actions Workflows:
* [`.github/workflows/linux.yml`](diffhunk://#diff-21364b2e6fae1f2875cee1ab3daefb0685403687eaf8bc32b5c6eacda351c9d3R1-R29): Added a new workflow for building the project on Linux. This includes steps for checking out the code, updating the version in the code, installing Qt, running QMake, and building the project.
* [`.github/workflows/macos.yml`](diffhunk://#diff-7b74d73de878e0e53f6768bbf3a3d4b50c3c6f1f16f9b64518690028b8206b1cR1-R37): Added a new workflow for building the project on macOS. This includes steps similar to the Linux workflow, with an additional step to create a DMG file and publish artifacts.

### Updates to Existing Workflow:
* [`.github/workflows/windows.yml`](diffhunk://#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773cL1-R1): Renamed from `build.yml` to `windows.yml` and removed the steps for building on Ubuntu and macOS, focusing solely on Windows. [[1]](diffhunk://#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773cL1-R1) [[2]](diffhunk://#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773cL10-R10)

### README Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R11): Updated to include separate badges for Linux, macOS, and Windows workflows. Added SonarCloud badges for quality gate status, bugs, reliability rating, security rating, maintainability rating, and vulnerabilities.