### PR TITLE
Add support for async export data with cancellation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ src/SQLiteQueryAnalyzer_autogen
 src/cmake_install.cmake
 src/CMakeCache.txt
 src/SQLiteQueryAnalyzer
+src/.cmake
+src/.ninja*
+src/build.ninja
+src/Testing

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -1,4 +1,15 @@
-cmake . -DCMAKE_PREFIX_PATH=C:/Qt/6.8.2/msvc2022_64 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /permissive-" -B build
-cmake --build build --config Release
-C:\Qt\6.8.2\msvc2022_64\bin\windeployqt.exe .\build\Release\SQLiteQueryAnalyzer.exe
-../deps/innosetup/ISCC.exe setup.iss
+if ($IsWindows) {
+    cmake . -DCMAKE_PREFIX_PATH=C:/Qt/6.8.2/msvc2022_64 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /permissive-" -B build
+    cmake --build build --config Release
+    C:\Qt\6.8.2\msvc2022_64\bin\windeployqt.exe .\build\Release\SQLiteQueryAnalyzer.exe
+    ../deps/innosetup/ISCC.exe setup.iss
+} 
+
+if ($IsLinux || $IsMacOS) {
+    cmake -B build
+    cmake --build build --config Release
+}
+
+if ($IsMacOS) {
+    macdeployqt build/SQLiteQueryAnalyzer.app
+}

--- a/src/dbexport.cpp
+++ b/src/dbexport.cpp
@@ -73,7 +73,9 @@ QStringList DbExport::getColumnValueDefinitions(const Table &table, const QSqlQu
     return valueDefinitions;
 }
 
-void DbExport::exportDataToFile(const Database *database, const QString &filename) const {
+void DbExport::exportDataToFile(const Database *database,
+                                const QString &filename,
+                                const bool *cancel) const {
     const auto file = std::make_unique<QFile>(filename);
     if (!file->open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate))
         return;
@@ -91,6 +93,9 @@ void DbExport::exportDataToFile(const Database *database, const QString &filenam
             const auto values = getColumnValueDefinitions(table, query).join(", ");
             out << "INSERT INTO " << table.name << "(" << columns << ") ";
             out << "VALUES (" << values << ");\n";
+            if (cancel && *cancel) {
+                break;
+            }
         }
         out << "\n";
     }

--- a/src/dbexport.h
+++ b/src/dbexport.h
@@ -19,7 +19,7 @@ public:
 
     [[nodiscard]] QStringList getColumnValueDefinitions(const Table &table, const QSqlQuery &query) const;
 
-    void exportDataToFile(const Database *database, const QString & filename) const;
+    void exportDataToFile(const Database *database, const QString &filename, const bool *cancel) const;
 
 private:
     DatabaseInfo info;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -101,6 +101,7 @@ QString MainWindow::showFileDialog(const QFileDialog::AcceptMode mode) {
 void MainWindow::createNewFile() {
     if (this->dataExportInProgress) {
         ui->queryResultMessagesTextEdit->setPlainText("Unable to process request. Data export in progress");
+        ui->queryResultTab->setCurrentIndex(1);
         return;
     }
 
@@ -113,6 +114,7 @@ void MainWindow::createNewFile() {
 void MainWindow::openDatabase(const QString &filename) const {
     if (this->dataExportInProgress) {
         ui->queryResultMessagesTextEdit->setPlainText("Unable to process request. Data export in progress");
+        ui->queryResultTab->setCurrentIndex(1);
         return;
     }
 
@@ -139,6 +141,7 @@ void MainWindow::openDatabase(const QString &filename) const {
 void MainWindow::openExistingFile() {
     if (this->dataExportInProgress) {
         ui->queryResultMessagesTextEdit->setPlainText("Unable to process request. Data export in progress");
+        ui->queryResultTab->setCurrentIndex(1);
         return;
     }
     QString filepath = this->showFileDialog(QFileDialog::AcceptOpen);
@@ -154,6 +157,7 @@ void MainWindow::appExit() {
 void MainWindow::shrink() const {
     if (this->dataExportInProgress) {
         ui->queryResultMessagesTextEdit->setPlainText("Unable to process request. Data export in progress");
+        ui->queryResultTab->setCurrentIndex(1);
         return;
     }
     const QString filename = this->database->getFilename();
@@ -171,6 +175,7 @@ void MainWindow::refreshDatabase() const {
 void MainWindow::analyzeDatabase() const {
     if (this->dataExportInProgress) {
         ui->queryResultMessagesTextEdit->setPlainText("Unable to process request. Data export in progress");
+        ui->queryResultTab->setCurrentIndex(1);
         return;
     }
 
@@ -188,6 +193,7 @@ void MainWindow::analyzeDatabase() const {
 void MainWindow::executeQuery() const {
     if (this->dataExportInProgress) {
         ui->queryResultMessagesTextEdit->setPlainText("Unable to process request. Data export in progress");
+        ui->queryResultTab->setCurrentIndex(1);
         return;
     }
 
@@ -221,6 +227,7 @@ void MainWindow::executeQuery() const {
 void MainWindow::scriptSchema() const {
     if (this->dataExportInProgress) {
         ui->queryResultMessagesTextEdit->setPlainText("Unable to process request. Data export in progress");
+        ui->queryResultTab->setCurrentIndex(1);
         return;
     }
     DatabaseInfo info;
@@ -277,6 +284,7 @@ void MainWindow::treeNodeChanged(QTreeWidgetItem *item) const {
 void MainWindow::treeNodeChanged(QTreeWidgetItem *item, const int column) const {
     if (this->dataExportInProgress) {
         ui->queryResultMessagesTextEdit->setPlainText("Unable to process request. Data export in progress");
+        ui->queryResultTab->setCurrentIndex(1);
         return;
     }
     if (item && item->type() == QTreeWidgetItem::UserType + 1) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -238,6 +238,7 @@ void MainWindow::scriptData() {
     DatabaseInfo info;
     analyzer->analyze(info);
     ui->actionScript_Data->setEnabled(false);
+    ui->actionExecute_Query->setEnabled(false);
     this->dataExportInProgress = true;
 
     auto future = QtConcurrent::run([this, info, filepath]()
@@ -250,6 +251,7 @@ void MainWindow::scriptData() {
             runInMainThread( [this]()
             {
                 ui->actionScript_Data->setEnabled(true);
+                ui->actionExecute_Query->setEnabled(true);
                 this->dataExportInProgress = false;
             });
         });

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QFileDialog>
+#include <qfuturewatcher.h>
 
 #include "dbanalyzer.h"
 #include "dbquery.h"
@@ -36,7 +37,11 @@ public slots:
 
     void scriptSchema() const;
 
+    void setEnabledActions(bool);
+
     void scriptData();
+
+    void cancel();
 
     void saveSql();
 
@@ -61,6 +66,7 @@ private:
     DbTree *tree;
     Highlighter *highlighter;
     bool dataExportInProgress = false;
+    bool cancelExport;
 
     QString showFileDialog(QFileDialog::AcceptMode mode);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -60,10 +60,19 @@ private:
     DbQuery *query;
     DbTree *tree;
     Highlighter *highlighter;
+    bool dataExportInProgress = false;
 
     QString showFileDialog(QFileDialog::AcceptMode mode);
 
     void analyzeDatabase() const;
+
+    template<typename F>
+    void runInMainThread(F&& fun)
+    {
+        QObject tmp;
+        QObject::connect(&tmp, &QObject::destroyed, qApp, std::forward<F>(fun),
+                         Qt::QueuedConnection);
+    }
 };
 
 #endif // MAINWINDOW_H

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -119,6 +119,7 @@
     <addaction name="actionShrink"/>
     <addaction name="actionScript_Schema"/>
     <addaction name="actionScript_Data"/>
+    <addaction name="actionCancel"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
@@ -218,6 +219,14 @@
   <action name="actionScript_Data">
    <property name="text">
     <string>Script Data</string>
+   </property>
+  </action>
+  <action name="actionCancel">
+   <property name="text">
+    <string>Cancel</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This pull request introduces several significant changes to improve the build process, enhance data export functionality, and add cancellation capabilities for ongoing operations in the application.

### Build process improvements:
* [`src/build.ps1`](diffhunk://#diff-0a79f8128018ad45b36df274b955057e8200498bcc31a1825bca64b6a326eac1R1-R15): Added conditional statements to handle the build process for Windows, Linux, and macOS separately, including the use of `windeployqt` for Windows and `macdeployqt` for macOS.

### Data export enhancements:
* `src/dbexport.cpp` and `src/dbexport.h`: Updated the `DbExport::exportDataToFile` method to accept a `cancel` parameter, allowing the export process to be interrupted. [[1]](diffhunk://#diff-f2171b1ae50c0dce2751bf55522c166ee267b871b938b440412a70b18445580bL76-R78) [[2]](diffhunk://#diff-f2171b1ae50c0dce2751bf55522c166ee267b871b938b440412a70b18445580bR96-R98) [[3]](diffhunk://#diff-25a59fddd8de1b1c2fe374c5e2ca5ada36c44f161635184821f4b841b7228b14L22-R22)

### User interface and functionality improvements:
* `src/mainwindow.cpp` and `src/mainwindow.h`: Added a new slot `cancel` to handle cancellation of data export operations, and updated various methods to check if a data export is in progress before proceeding with their operations. [[1]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R11) [[2]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R30) [[3]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L101-R107) [[4]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L110-R120) [[5]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L133-R163) [[6]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L160-R181) [[7]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L174-R199) [[8]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R229-R275) [[9]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R296-R300) [[10]](diffhunk://#diff-043d32442474a7903890f612e2ffb16d87f94a94a6814ad6cbf2a57e7372942dR6) [[11]](diffhunk://#diff-043d32442474a7903890f612e2ffb16d87f94a94a6814ad6cbf2a57e7372942dR40-R45) [[12]](diffhunk://#diff-043d32442474a7903890f612e2ffb16d87f94a94a6814ad6cbf2a57e7372942dR68-R81)

### UI file updates:
* [`src/mainwindow.ui`](diffhunk://#diff-3fcaf4581164efa66fce7f8353e9b4a4203d36b7cb6f9effe08cc510f8a3858aR122): Added a new `actionCancel` action to the UI, which is initially hidden and becomes visible when a data export is in progress. [[1]](diffhunk://#diff-3fcaf4581164efa66fce7f8353e9b4a4203d36b7cb6f9effe08cc510f8a3858aR122) [[2]](diffhunk://#diff-3fcaf4581164efa66fce7f8353e9b4a4203d36b7cb6f9effe08cc510f8a3858aR224-R231)