### PR TITLE
Implement Export Data progress reporting

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ qt_add_executable(SQLiteQueryAnalyzer WIN32 MACOSX_BUNDLE
         settings.cpp settings.h
         dbexport.cpp dbexport.h
         cancellation.cpp cancellation.h
+        mainthread.h
 )
 target_link_libraries(SQLiteQueryAnalyzer PRIVATE
         Qt::Core

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,7 @@ qt_add_executable(SQLiteQueryAnalyzer WIN32 MACOSX_BUNDLE
         recentfiles.cpp recentfiles.h
         settings.cpp settings.h
         dbexport.cpp dbexport.h
-        cancellation.cpp    cancellation.h
+        cancellation.cpp cancellation.h
 )
 target_link_libraries(SQLiteQueryAnalyzer PRIVATE
         Qt::Core

--- a/src/SQLiteAnalyzer.pro
+++ b/src/SQLiteAnalyzer.pro
@@ -37,6 +37,7 @@ HEADERS  += mainwindow.h \
     recentfiles.h \
     settings.h \
     dbexport.h \
-    cancellation.h
+    cancellation.h \
+    mainthread.h
 
 FORMS    += mainwindow.ui

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -5,7 +5,7 @@ if ($IsWindows) {
     ../deps/innosetup/ISCC.exe setup.iss
 } 
 
-if ($IsLinux || $IsMacOS) {
+if ($IsLinux -or $IsMacOS) {
     cmake -B build
     cmake --build build --config Release
 }

--- a/src/dbexport.cpp
+++ b/src/dbexport.cpp
@@ -75,7 +75,8 @@ QStringList DbExport::getColumnValueDefinitions(const Table &table, const QSqlQu
 
 void DbExport::exportDataToFile(const Database *database,
                                 const QString &filename,
-                                const CancellationToken *cancel) const {
+                                const CancellationToken *cancellation_token,
+                                ExportDataProgress *progress) const {
     const auto file = std::make_unique<QFile>(filename);
     if (!file->open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate))
         return;
@@ -93,7 +94,8 @@ void DbExport::exportDataToFile(const Database *database,
             const auto values = getColumnValueDefinitions(table, query).join(", ");
             out << "INSERT INTO " << table.name << "(" << columns << ") ";
             out << "VALUES (" << values << ");\n";
-            if (cancel->isCancellationRequested()) {
+            progress->increment();
+            if (cancellation_token->isCancellationRequested()) {
                 break;
             }
         }

--- a/src/dbexport.h
+++ b/src/dbexport.h
@@ -1,8 +1,9 @@
 #ifndef DBEXPORT_H
 #define DBEXPORT_H
 
+#include "cancellation.h"
+#include "database.h"
 #include "databaseinfo.h"
-#include "mainwindow.h"
 
 class ExportDataProgress {
     uint64_t affectedRows = 0;
@@ -27,7 +28,8 @@ public:
 
     void exportDataToFile(const Database *database,
                           const QString &filename,
-                          const CancellationToken *cancellation_token) const;
+                          const CancellationToken *cancellation_token,
+                          ExportDataProgress *progress) const;
 
 private:
     DatabaseInfo info;

--- a/src/dbexport.h
+++ b/src/dbexport.h
@@ -4,6 +4,12 @@
 #include "databaseinfo.h"
 #include "mainwindow.h"
 
+class ExportDataProgress {
+    uint64_t affectedRows = 0;
+public:
+    void increment() { affectedRows++; }
+    uint64_t getAffectedRows() const { return affectedRows; }
+};
 
 class DbExport {
 public:

--- a/src/mainthread.h
+++ b/src/mainthread.h
@@ -1,0 +1,21 @@
+#ifndef MAINTHREAD_H
+#define MAINTHREAD_H
+
+#include <QGuiApplication>
+#include <QObject>
+
+class MainThread {
+public:
+    template<typename F>
+    static void run(F &&fun) {
+        QObject tmp;
+        QObject::connect(&tmp,
+                         &QObject::destroyed,
+                         qApp,
+                         std::forward<F>(fun),
+                         Qt::QueuedConnection);
+    }
+};
+
+
+#endif //MAINTHREAD_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3,6 +3,7 @@
 #include "ui_mainwindow.h"
 #include "settings.h"
 #include "dbexport.h"
+#include "mainthread.h"
 
 #include <QMessageBox>
 #include <QSqlTableModel>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -265,7 +265,7 @@ void MainWindow::scriptData() {
         exporter->exportDataToFile(database, filepath, &cancellationToken, progress);
     });
     future.then([this, cancellationToken, progress]() {
-        runInMainThread([this, cancellationToken, progress]() {
+        MainThread::run([this, cancellationToken, progress]() {
             this->setEnabledActions(true);
             if (cancellationToken.isCancellationRequested())
                 ui->queryResultMessagesTextEdit->setPlainText(
@@ -273,16 +273,6 @@ void MainWindow::scriptData() {
                     QString("%1 row(s)").arg(progress->getAffectedRows()));
         });
     });
-}
-
-template<typename F>
-void MainWindow::runInMainThread(F &&fun) {
-    QObject tmp;
-    QObject::connect(&tmp,
-                     &QObject::destroyed,
-                     qApp,
-                     std::forward<F>(fun),
-                     Qt::QueuedConnection);
 }
 
 void MainWindow::cancel() const {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -241,7 +241,7 @@ void MainWindow::setEnabledActions(const bool enabled) {
     ui->actionExecute_Query->setEnabled(enabled);
     ui->actionScript_Schema->setEnabled(enabled);
     ui->actionCancel->setVisible(!enabled);
-    if (enabled){
+    if (enabled) {
         this->dataExportProgress.release();
     }
 }
@@ -299,7 +299,9 @@ void MainWindow::treeNodeChanged(QTreeWidgetItem *item) const {
 
 void MainWindow::treeNodeChanged(QTreeWidgetItem *item, const int column) const {
     if (this->dataExportProgress.get() != nullptr) {
-        ui->queryResultMessagesTextEdit->setPlainText("Unable to process request. Data export in progress - " + QString("%1 row(s)").arg(this->dataExportProgress.get()->getAffectedRows()));
+        ui->queryResultMessagesTextEdit->setPlainText(
+            "Unable to process request. Data export in progress - " + QString("%1 row(s)").arg(
+                this->dataExportProgress.get()->getAffectedRows()));
         ui->queryResultTab->setCurrentIndex(1);
         return;
     }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -7,6 +7,7 @@
 
 #include "cancellation.h"
 #include "dbanalyzer.h"
+#include "dbexport.h"
 #include "dbquery.h"
 #include "highlighter.h"
 #include "dbtree.h"
@@ -66,7 +67,7 @@ private:
     DbQuery *query;
     DbTree *tree;
     Highlighter *highlighter;
-    bool dataExportInProgress = false;
+    std::unique_ptr<ExportDataProgress> dataExportProgress;
     std::unique_ptr<CancellationTokenSource> tcs;
 
     QString showFileDialog(QFileDialog::AcceptMode mode);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -73,9 +73,6 @@ private:
     QString showFileDialog(QFileDialog::AcceptMode mode);
 
     void analyzeDatabase() const;
-
-    template<typename F>
-    auto runInMainThread(F &&fun) -> void;
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the SQLite Query Analyzer project. The most significant changes include the addition of a new `ExportDataProgress` class to track export progress, the replacement of `dataExportInProgress` with `dataExportProgress` in `MainWindow`, and the introduction of a `MainThread` utility class for running tasks on the main thread.

### Enhancements to Export Functionality:
* `src/dbexport.h` and `src/dbexport.cpp`: Added `ExportDataProgress` class to track the number of affected rows during data export and updated `exportDataToFile` method to accept an `ExportDataProgress` pointer. [[1]](diffhunk://#diff-25a59fddd8de1b1c2fe374c5e2ca5ada36c44f161635184821f4b841b7228b14R4-R13) [[2]](diffhunk://#diff-25a59fddd8de1b1c2fe374c5e2ca5ada36c44f161635184821f4b841b7228b14L24-R32) [[3]](diffhunk://#diff-f2171b1ae50c0dce2751bf55522c166ee267b871b938b440412a70b18445580bL78-R79) [[4]](diffhunk://#diff-f2171b1ae50c0dce2751bf55522c166ee267b871b938b440412a70b18445580bL96-R98)

### Refactoring in `MainWindow`:
* `src/mainwindow.cpp` and `src/mainwindow.h`: Replaced `dataExportInProgress` boolean with a `std::unique_ptr<ExportDataProgress>` to better manage export progress and updated related methods to check `dataExportProgress` instead of `dataExportInProgress`. [[1]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L103-R104) [[2]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L116-R117) [[3]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L143-R144) [[4]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L159-R160) [[5]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L177-R178) [[6]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L195-R196) [[7]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L229-L233) [[8]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L248-R246) [[9]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L260-L284) [[10]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L307-R304) [[11]](diffhunk://#diff-043d32442474a7903890f612e2ffb16d87f94a94a6814ad6cbf2a57e7372942dL69-L77)

### Utility Class for Main Thread Execution:
* [`src/mainthread.h`](diffhunk://#diff-7962481b2d8dcee64e9a436aee85a7c45a544d41aaba84d0cd0a03da93b2b134R1-R21): Introduced a new `MainThread` class with a static `run` method to facilitate running tasks on the main thread using Qt's event system.

### Build System Adjustments:
* `src/CMakeLists.txt` and `src/SQLiteAnalyzer.pro`: Added `mainthread.h` to the project files. [[1]](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4R32) [[2]](diffhunk://#diff-7973f19edc5de346c77252bd40cdb33bcaf973b7033b89a4fc8eb8ae8c4cd75cL40-R41)
* [`src/build.ps1`](diffhunk://#diff-0a79f8128018ad45b36df274b955057e8200498bcc31a1825bca64b6a326eac1L8-R8): Updated conditional syntax for Linux and macOS builds for better compatibility.

These changes collectively improve the functionality and maintainability of the SQLite Query Analyzer project by enhancing data export tracking, refactoring the `MainWindow` class, and introducing a utility for main thread execution.