### PR TITLE
Show Export Data Progress

### DIFF
--- a/src/dbexport.h
+++ b/src/dbexport.h
@@ -8,6 +8,7 @@
 class ExportDataProgress {
     uint64_t affectedRows = 0;
 public:
+    void reset() { affectedRows = 0; }
     void increment() { affectedRows++; }
     uint64_t getAffectedRows() const { return affectedRows; }
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -267,7 +267,7 @@ void MainWindow::showExportDataProgress(const std::unique_ptr<ExportDataProgress
     });
 }
 
-void MainWindow::scriptDataAsync(const QString& filepath,
+void MainWindow::exportDataAsync(const QString& filepath,
                                  const DatabaseInfo& info,
                                  const std::unique_ptr<ExportDataProgress>::pointer progress,
                                  const CancellationToken cancellationToken)
@@ -288,7 +288,7 @@ void MainWindow::scriptDataAsync(const QString& filepath,
     });
 }
 
-void MainWindow::scriptData() {
+void MainWindow::exportData() {
     const QString filepath = this->showFileDialog(QFileDialog::AcceptSave);
     if (filepath.isEmpty())
         return;
@@ -304,7 +304,7 @@ void MainWindow::scriptData() {
     this->tcs = std::make_unique<CancellationTokenSource>();
     const auto cancellationToken = tcs->get();
 
-    scriptDataAsync(filepath, info, progress, cancellationToken);
+    exportDataAsync(filepath, info, progress, cancellationToken);
     showExportDataProgress(progress, cancellationToken);
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -256,6 +256,7 @@ void MainWindow::scriptData() {
     DatabaseInfo info;
     analyzer->analyze(info);
     this->setEnabledActions(false);
+    ui->queryResultTab->setCurrentIndex(1);
 
     this->dataExportProgress = std::make_unique<ExportDataProgress>();
     const auto progress = dataExportProgress.get();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -42,10 +42,10 @@ public slots:
     void setEnabledActions(bool);
     void showExportDataProgress(std::unique_ptr<ExportDataProgress>::pointer progress,
                                 CancellationToken cancellationToken) const;
-    void scriptDataAsync(const QString& filepath, const DatabaseInfo& info, std::unique_ptr<ExportDataProgress>::pointer progress,
+    void exportDataAsync(const QString& filepath, const DatabaseInfo& info, std::unique_ptr<ExportDataProgress>::pointer progress,
                          CancellationToken cancellationToken);
 
-    void scriptData();
+    void exportData();
 
     void cancel() const;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -40,6 +40,10 @@ public slots:
     void scriptSchema() const;
 
     void setEnabledActions(bool);
+    void showExportDataProgress(std::unique_ptr<ExportDataProgress>::pointer progress,
+                                CancellationToken cancellationToken) const;
+    void scriptDataAsync(const QString& filepath, const DatabaseInfo& info, std::unique_ptr<ExportDataProgress>::pointer progress,
+                         CancellationToken cancellationToken);
 
     void scriptData();
 


### PR DESCRIPTION
This pull request focuses on enhancing the data export functionality and improving code organization in the `MainWindow` class. The most important changes include the addition of new methods for handling data export progress and cancellation, as well as the refactoring of existing methods to streamline the export process.

Enhancements to data export functionality:

* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L249-R278): Introduced `showExportDataProgress` and `exportDataAsync` methods to handle data export progress updates and asynchronous export operations. This improves the user interface by providing real-time feedback on the export progress. [[1]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L249-R278) [[2]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R291-R310)
* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R291-R310): Refactored the `scriptData` method into a new `exportData` method, which now utilizes the newly introduced methods for a more organized and efficient export process.

Code organization improvements:

* [`src/dbexport.h`](diffhunk://#diff-25a59fddd8de1b1c2fe374c5e2ca5ada36c44f161635184821f4b841b7228b14R11): Added a `reset` method to the `ExportDataProgress` class to allow resetting the affected rows count.
* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R13-R14): Included additional headers (`<chrono>` and `<thread>`) to support the new asynchronous operations and progress updates.
* [`src/mainwindow.h`](diffhunk://#diff-043d32442474a7903890f612e2ffb16d87f94a94a6814ad6cbf2a57e7372942dR43-R48): Updated the public slots to include the new methods `showExportDataProgress`, `exportDataAsync`, and `exportData`. Removed the now-obsolete `scriptData` method.