### PR TITLE
Save window size and position and reuse upon next launch

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -24,7 +24,7 @@ public:
 
     ~MainWindow() override;
 
-    void resizeEvent(QResizeEvent *e);
+    void resizeEvent(QResizeEvent *e) override;
 
     void loadRecentFiles() const;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -24,6 +24,8 @@ public:
 
     ~MainWindow() override;
 
+    void resizeEvent(QResizeEvent *e);
+
     void loadRecentFiles() const;
 
     void openDatabase(const QString &filename) const;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2,8 +2,14 @@
 
 #include <QStandardPaths>
 #include <QDir>
+#include <QApplication>
+#include <QSettings>
 
 void Settings::init() {
+    QApplication::setOrganizationDomain("christianhelle.com");
+    QApplication::setOrganizationName("Christian Helle");
+    QApplication::setApplicationName("SQLite Query Analyzer");
+
     const auto path = getSettingsFolder();
     if (const QDir dir(path); !dir.exists() && !dir.mkdir(path)) {
         qDebug("Failed to create settings directory");
@@ -26,4 +32,20 @@ QString Settings::getSettingsFolder() {
     constexpr auto type = QStandardPaths::HomeLocation;
     const auto home_path = QStandardPaths::writableLocation(type);
     return home_path + "/.sqlite_query_analyzer";
+}
+
+void Settings::getMainWindowState(WindowState *state) {
+    QSettings settings;
+    settings.beginGroup("MainWindow");
+    state->size = settings.value("main_window_size", QSize(800, 600)).toSize();
+    state->position = settings.value("main_window_position", QPoint(0, 0)).toPoint();
+    settings.endGroup();
+}
+
+void Settings::setMainWindowState(const QSizeF &size, const QPoint &position) {
+    QSettings settings;
+    settings.beginGroup("MainWindow");
+    settings.setValue("main_window_size", size);
+    settings.setValue("main_window_position", position);
+    settings.endGroup();
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,13 +1,21 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
-#include <QString>
+#include <QPoint>
+#include <QSizeF>
+
+struct WindowState {
+    QSize size;
+    QPoint position;
+};
 
 class Settings {
 public:
     static void init();
 
     static QString getSettingsFolder();
+    static void getMainWindowState(WindowState *state);
+    static void setMainWindowState(const QSizeF &size, const QPoint &position);
 };
 
 


### PR DESCRIPTION
This pull request includes several changes to the `MainWindow` class and the `Settings` class to implement and manage the window state (size and position) of the main application window. Additionally, it includes some minor formatting adjustments.

Changes to manage window state:

* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R53-R58): Added code to initialize the window state on startup and save the state on resize events. (`[[1]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R53-R58)`, `[[2]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R74-R77)`)
* [`src/settings.cpp`](diffhunk://#diff-c044ba02ccf7862f1e2f56436d5b92baa7bb35601791846655fb07ac253a8697R36-R51): Added methods to get and set the main window state using `QSettings`. (`[src/settings.cppR36-R51](diffhunk://#diff-c044ba02ccf7862f1e2f56436d5b92baa7bb35601791846655fb07ac253a8697R36-R51)`)
* [`src/settings.h`](diffhunk://#diff-e43eb64bdd9061c058d0e50763df67fe62bf719f55bcff809d1eadda8eb67513L4-R18): Added a `WindowState` struct and declarations for the new methods in the `Settings` class. (`[src/settings.hL4-R18](diffhunk://#diff-e43eb64bdd9061c058d0e50763df67fe62bf719f55bcff809d1eadda8eb67513L4-R18)`)

Minor formatting adjustments:

* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L252-R262): Adjusted the formatting of the `showExportDataProgress` and `exportDataAsync` methods. (`[[1]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L252-R262)`, `[[2]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L273-R282)`)