### PR TITLE
Fix Export Data not starting

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -316,6 +316,12 @@ void MainWindow::exportData() {
 }
 
 void MainWindow::cancel() const {
+    if (this->dataExportProgress != nullptr) {
+        ui->queryResultMessagesTextEdit->setPlainText(
+            "Data export cancelled. Exported " +
+            QString("%1 row(s)").arg(this->dataExportProgress->getAffectedRows()));
+    }
+
     this->tcs->cancel();
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -29,7 +29,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent),
     connect(ui->actionExecute_Query, SIGNAL(triggered()), this, SLOT(executeQuery()));
     connect(ui->actionShrink, SIGNAL(triggered()), this, SLOT(shrink()));
     connect(ui->actionScript_Schema, SIGNAL(triggered()), this, SLOT(scriptSchema()));
-    connect(ui->actionScript_Data, SIGNAL(triggered()), this, SLOT(scriptData()));
+    connect(ui->actionScript_Data, SIGNAL(triggered()), this, SLOT(exportData()));
     connect(ui->actionCancel, SIGNAL(triggered()), this, SLOT(cancel()));
     connect(ui->treeWidget, SIGNAL(itemActivated(QTreeWidgetItem*,int)), this,
             SLOT(treeNodeChanged(QTreeWidgetItem*,int)));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -57,7 +57,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent),
         this->move(windowState.position);
 
     this->loadRecentFiles();
-    // this->openExistingFile();
 }
 
 MainWindow::~MainWindow() {


### PR DESCRIPTION
This pull request includes changes to the `MainWindow` class in `src/mainwindow.cpp` to improve functionality and user feedback. The most important changes include modifying the `actionScript_Data` signal to call `exportData` instead of `scriptData`, removing commented-out code, and enhancing the `cancel` method to provide feedback on data export progress.

Signal and slot improvements:

* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L32-R32): Changed the `actionScript_Data` signal to trigger the `exportData` slot instead of the `scriptData` slot.

Code cleanup:

* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L60): Removed commented-out code in the `MainWindow` constructor.

User feedback enhancements:

* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R319-R324): Updated the `cancel` method to provide feedback on the number of rows exported when a data export is cancelled.