### PR TITLE
Setup Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}
+          asset_path: artifacts/SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}
           asset_name: SQLiteAnalyzer-Setup.exe
           asset_content_type: application/zip
       - name: Upload VSIX for VS2022 asset
@@ -161,6 +161,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}
+          asset_path: artifacts/SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}
           asset_name: SQLiteAnalyzer-Windows.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: artifacts/SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}/SQLiteQueryAnalyzer-Setup.exe
-          asset_name: SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}.exe
+          asset_name: SQLiteQuerAnalyzer for Windows (Installer) v${{ env.VERSION }}.exe
           asset_content_type: application/zip
       - name: Upload Windows Binary
         uses: actions/upload-release-asset@v1
@@ -162,7 +162,7 @@ jobs:
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: artifacts/SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}/SQLiteQueryAnalyzer_Windows.zip
-          asset_name: SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}.zip
+          asset_name: SQLiteQuerAnalyzer for Windows (Binaries) v${{ env.VERSION }}.zip
           asset_content_type: application/zip
       - name: Upload MacOS disk image
         uses: actions/upload-release-asset@v1
@@ -171,5 +171,5 @@ jobs:
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: artifacts/SQLiteQuerAnalyzer_MacOS_v${{ env.VERSION }}/SQLiteQueryAnalyzer.dmg
-          asset_name: SQLiteQuerAnalyzer_MacOS_v${{ env.VERSION }}.dmg
+          asset_name: SQLiteQuerAnalyzer for MacOS v${{ env.VERSION }}.dmg
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         name: SQLiteQuerAnalyzer_MacOS_v${{ env.VERSION }}
         path: |
-          src/*.dmg
+          src/build/*.dmg
   windows:
     name: Windows
     runs-on:  windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,8 +152,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: artifacts/Visual Studio Extension/ApiClientCodeGenerator-VS2019-${{ env.VERSION }}.vsix
-          asset_name: ApiClientCodeGenerator-VS2019-${{ env.VERSION }}.vsix
+          asset_path: src/Artifacts/SQLiteAnalyzer-Setup.exe
+          asset_name: SQLiteAnalyzer-Setup.exe
           asset_content_type: application/zip
       - name: Upload VSIX for VS2022 asset
         uses: actions/upload-release-asset@v1
@@ -161,10 +161,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: artifacts/Visual Studio Extension/ApiClientCodeGenerator-VS2022-${{ env.VERSION }}.vsix
-          asset_name: ApiClientCodeGenerator-VS2022-${{ env.VERSION }}.vsix
+          asset_path: src/Artifacts/SQLiteAnalyzer-Windows.zip
+          asset_name: SQLiteAnalyzer-Windows.zip
           asset_content_type: application/zip
-      - uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         name: SQLiteQuerAnalyzer_MacOS_v${{ env.VERSION }}
         path: |
-          **/*.dmg
+          src/build/SQLiteQueryAnalyzer.dmg
   windows:
     name: Windows
     runs-on:  windows-latest
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
-      - name: Upload Windows Installer asset
+      - name: Upload Windows Installer
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -155,7 +155,7 @@ jobs:
           asset_path: artifacts/SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}/SQLiteQueryAnalyzer-Setup.exe
           asset_name: SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}.exe
           asset_content_type: application/zip
-      - name: Upload Windows Binary asset
+      - name: Upload Windows Binary
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -163,4 +163,13 @@ jobs:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: artifacts/SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}/SQLiteQueryAnalyzer_Windows.zip
           asset_name: SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}.zip
+          asset_content_type: application/zip
+      - name: Upload MacOS disk image
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: artifacts/SQLiteQuerAnalyzer_MacOS_v${{ env.VERSION }}/SQLiteQueryAnalyzer.dmg
+          asset_name: SQLiteQuerAnalyzer_MacOS_v${{ env.VERSION }}.dmg
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         version: '6.8.2'
     - name: Build
+      working-directory: src
       run: |
         qmake
         make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: src/Artifacts/SQLiteAnalyzer-Setup.exe
+          asset_path: SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}
           asset_name: SQLiteAnalyzer-Setup.exe
           asset_content_type: application/zip
       - name: Upload VSIX for VS2022 asset
@@ -161,6 +161,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: src/Artifacts/SQLiteAnalyzer-Windows.zip
+          asset_path: SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}
           asset_name: SQLiteAnalyzer-Windows.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: artifacts/SQLiteQueryAnalyzer-Setup.exe
+          asset_path: artifacts/SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}/SQLiteQueryAnalyzer-Setup.exe
           asset_name: SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}.exe
           asset_content_type: application/zip
       - name: Upload Windows Binary asset
@@ -161,6 +161,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: artifacts/SQLiteQueryAnalyzer_Windows.zip
+          asset_path: artifacts/SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}/SQLiteQueryAnalyzer_Windows.zip
           asset_name: SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,15 +152,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: artifacts/SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}.exe
+          asset_path: artifacts/SQLiteQueryAnalyzer-Setup.exe
           asset_name: SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}.exe
           asset_content_type: application/zip
-      - name: Upload VSIX for VS2022 asset
+      - name: Upload Windows Binary asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: artifacts/SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}.zip
+          asset_path: artifacts/SQLiteQueryAnalyzer_Windows.zip
           asset_name: SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: artifacts/SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}
+          asset_path: artifacts/SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}.exe
           asset_name: SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}.exe
           asset_content_type: application/zip
       - name: Upload VSIX for VS2022 asset
@@ -161,6 +161,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: artifacts/SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}
+          asset_path: artifacts/SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}.zip
           asset_name: SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,7 @@ jobs:
         version: '6.8.2'
     - name: Build
       working-directory: src
-      run: |
-        qmake
-        make
-        macdeployqt SQLiteQueryAnalyzer.app -dmg
+      run: pwsh build.ps1
     - name: Publish artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: artifacts/SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}
-          asset_name: SQLiteAnalyzer-Setup.exe
+          asset_name: SQLiteQuerAnalyzer_Windows_Installer_v${{ env.VERSION }}.exe
           asset_content_type: application/zip
       - name: Upload VSIX for VS2022 asset
         uses: actions/upload-release-asset@v1
@@ -162,5 +162,5 @@ jobs:
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: artifacts/SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}
-          asset_name: SQLiteAnalyzer-Windows.zip
+          asset_name: SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         name: SQLiteQuerAnalyzer_MacOS_v${{ env.VERSION }}
         path: |
-          src/build/*.dmg
+          **/*.dmg
   windows:
     name: Windows
     runs-on:  windows-latest

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -11,5 +11,5 @@ if ($IsLinux -or $IsMacOS) {
 }
 
 if ($IsMacOS) {
-    macdeployqt build/SQLiteQueryAnalyzer.app
+    macdeployqt build/SQLiteQueryAnalyzer.app -dmg
 }


### PR DESCRIPTION
This pull request includes changes to the build and release process for the project, specifically in the `.github/workflows/release.yml` and `src/build.ps1` files. The most important changes involve transitioning to a PowerShell-based build script for macOS, updating artifact paths and names, and ensuring the macOS app is packaged as a disk image.

Changes to build and release process:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L28-R35): Changed the build step for macOS to use a PowerShell script (`build.ps1`) and specified the working directory as `src`. Updated the artifact path for macOS to `src/build/SQLiteQueryAnalyzer.dmg`.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L151-R175): Updated the names and paths for Windows installer and binary assets. Added a new step to upload the macOS disk image as a release asset.

Changes to build script:

* [`src/build.ps1`](diffhunk://#diff-0a79f8128018ad45b36df274b955057e8200498bcc31a1825bca64b6a326eac1L14-R14): Added the `-dmg` option to `macdeployqt` for macOS to ensure the app is packaged as a disk image.