### PR TITLE
Fix incorrect version display on installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Update Version Number (Inno Setup)
         shell: pwsh
         run: |
-          $version = (Get-Content -Path src/setup.iss -Raw) -replace '#define MyAppVersion = "1.0.0"', '#define MyAppVersion = "${{ env.VERSION }}"'
+          $version = (Get-Content -Path src/setup.iss -Raw) -replace '#define MyAppVersion "1.0.0"', '#define MyAppVersion "${{ env.VERSION }}"'
           $version | Set-Content -Path src/setup.iss
 
       - name: Update Version in code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Update Version Number (Inno Setup)
         shell: pwsh
         run: |
-          $version = (Get-Content -Path src/setup.iss -Raw) -replace 'AppVersion = "1.0.0"', 'AppVersion = "${{ env.VERSION }}"'
+          $version = (Get-Content -Path src/setup.iss -Raw) -replace '#define MyAppVersion = "1.0.0"', '#define MyAppVersion = "${{ env.VERSION }}"'
           $version | Set-Content -Path src/setup.iss
 
       - name: Update Version in code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Update Version Number (Inno Setup)
         shell: pwsh
         run: |
-          $version = (Get-Content -Path src/setup.iss -Raw) -replace 'AppVersion = 1.0.0', 'AppVersion = ${{ env.VERSION }}'
+          $version = (Get-Content -Path src/setup.iss -Raw) -replace 'AppVersion = "1.0.0"', 'AppVersion = "${{ env.VERSION }}"'
           $version | Set-Content -Path src/setup.iss
 
       - name: Update Version in code

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Update Version Number (Inno Setup)
         shell: pwsh
         run: |
-          $version = (Get-Content -Path src/setup.iss -Raw) -replace 'AppVersion = 1.0.0', 'AppVersion = ${{ env.VERSION }}'
+          $version = (Get-Content -Path src/setup.iss -Raw) -replace 'AppVersion = "1.0.0"', 'AppVersion = "${{ env.VERSION }}"'
           $version | Set-Content -Path src/setup.iss
 
       - name: Update Version in code

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Update Version Number (Inno Setup)
         shell: pwsh
         run: |
-          $version = (Get-Content -Path src/setup.iss -Raw) -replace 'AppVersion = "1.0.0"', 'AppVersion = "${{ env.VERSION }}"'
+          $version = (Get-Content -Path src/setup.iss -Raw) -replace '#define MyAppVersion = "1.0.0"', '#define MyAppVersion = "${{ env.VERSION }}"'
           $version | Set-Content -Path src/setup.iss
 
       - name: Update Version in code

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Update Version Number (Inno Setup)
         shell: pwsh
         run: |
-          $version = (Get-Content -Path src/setup.iss -Raw) -replace '#define MyAppVersion = "1.0.0"', '#define MyAppVersion = "${{ env.VERSION }}"'
+          $version = (Get-Content -Path src/setup.iss -Raw) -replace '#define MyAppVersion "1.0.0"', '#define MyAppVersion "${{ env.VERSION }}"'
           $version | Set-Content -Path src/setup.iss
 
       - name: Update Version in code


### PR DESCRIPTION
This pull request includes updates to the version number replacement logic in the Inno Setup scripts within the GitHub workflows. The changes ensure the correct version format is used in the `src/setup.iss` file.

Changes to version number replacement logic:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L51-R51): Modified the `Update Version Number (Inno Setup)` step to replace `#define MyAppVersion "1.0.0"` with `#define MyAppVersion "${{ env.VERSION }}"`.
* [`.github/workflows/windows.yml`](diffhunk://#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773cL25-R25): Modified the `Update Version Number (Inno Setup)` step to replace `#define MyAppVersion "1.0.0"` with `#define MyAppVersion "${{ env.VERSION }}"`.