### PR TITLE
House Keeping

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -96,7 +96,7 @@ QString MainWindow::showFileDialog(const QFileDialog::AcceptMode mode) {
 
     if (dialog.exec()) {
         QStringList files = dialog.selectedFiles();
-        if (files.length())
+        if (!files.empty())
             return files.first();
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -95,8 +95,7 @@ QString MainWindow::showFileDialog(const QFileDialog::AcceptMode mode) {
     dialog.setViewMode(QFileDialog::Detail);
 
     if (dialog.exec()) {
-        QStringList files = dialog.selectedFiles();
-        if (!files.empty())
+        if (QStringList files = dialog.selectedFiles(); !files.empty())
             return files.first();
     }
 


### PR DESCRIPTION
This pull request includes a small change to the `showFileDialog` method in the `src/mainwindow.cpp` file. The change simplifies the code by combining the declaration and condition check for `files` into a single line.

* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L98-R98): Simplified the code by combining the declaration of `files` and the condition check into a single line, replacing `files.length()` with `!files.empty()`.