### PR TITLE
Show Filename in Window Title

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -242,6 +242,8 @@ void MainWindow::openDatabase(const QString &filename) const {
         std::make_unique<QSqlTableModel>(ui->tableView->model());
         ui->tableView->setModel(Q_NULLPTR);
     }
+
+    this->setWindowTitle("SQLite Query Analyzer - " + filename);
 }
 
 void MainWindow::openExistingFile() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -164,12 +164,12 @@ void MainWindow::loadRecentFiles() const {
     }
 }
 
-void MainWindow::openRecentFile() const {
+void MainWindow::openRecentFile() {
     const QString file = sender()->objectName();
     this->openDatabase(file);
 }
 
-void MainWindow::restoreLastSession() const {
+void MainWindow::restoreLastSession() {
     SessionState state;
     Settings::getSessionState(&state);
     if (!state.sqliteFile.isEmpty()) {
@@ -214,7 +214,7 @@ void MainWindow::createNewFile() {
     this->loadRecentFiles();
 }
 
-void MainWindow::openDatabase(const QString &filename) const {
+void MainWindow::openDatabase(const QString &filename) {
     if (this->dataExportProgress.get() != nullptr) {
         ui->queryResultMessagesTextEdit->setPlainText("Unable to process request. Data export in progress");
         ui->queryResultTab->setCurrentIndex(1);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -30,9 +30,9 @@ public:
 
     void loadRecentFiles() const;
 
-    void openDatabase(const QString &filename) const;
+    void openDatabase(const QString &filename);
 
-    void restoreLastSession() const;
+    void restoreLastSession();
 
 public slots:
     void createNewFile();
@@ -70,7 +70,7 @@ public slots:
 
     void about();
 
-    void openRecentFile() const;
+    void openRecentFile();
 
 private:
     std::unique_ptr<Ui::MainWindow> ui;


### PR DESCRIPTION
This pull request includes several changes to the `MainWindow` class in `src/mainwindow.cpp` and `src/mainwindow.h` to remove unnecessary `const` qualifiers from member functions. Additionally, it modifies the `openDatabase` function to update the window title with the filename.

Removal of unnecessary `const` qualifiers:

* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L167-R172): Removed `const` qualifier from `openRecentFile`, `restoreLastSession`, and `openDatabase` member functions. [[1]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L167-R172) [[2]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447L217-R217)
* [`src/mainwindow.h`](diffhunk://#diff-043d32442474a7903890f612e2ffb16d87f94a94a6814ad6cbf2a57e7372942dL33-R35): Updated function declarations to remove `const` qualifier from `openRecentFile`, `restoreLastSession`, and `openDatabase`. [[1]](diffhunk://#diff-043d32442474a7903890f612e2ffb16d87f94a94a6814ad6cbf2a57e7372942dL33-R35) [[2]](diffhunk://#diff-043d32442474a7903890f612e2ffb16d87f94a94a6814ad6cbf2a57e7372942dL73-R73)

Additional functionality:

* [`src/mainwindow.cpp`](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R245-R246): Modified `openDatabase` to set the window title to "SQLite Query Analyzer - " followed by the filename.