### PR TITLE
Implement Forward only reads during Export Data for performance and memory optimization

### DIFF
--- a/src/dbexport.cpp
+++ b/src/dbexport.cpp
@@ -89,14 +89,16 @@ void DbExport::exportDataToFile(const Database *database,
         out << "-- " << table.name << "\n";
 
         QSqlQuery query(database->getDatabase());
+        query.setForwardOnly(true);
         query.exec(QString("SELECT * FROM %1").arg(table.name));
+        const auto columns = getColumnDefinitions(table).join(", ");
         while (query.next() && !cancellationToken->isCancellationRequested()) {
-            const auto columns = getColumnDefinitions(table).join(", ");
             const auto values = getColumnValueDefinitions(table, query).join(", ");
             out << "INSERT INTO " << table.name << "(" << columns << ") ";
             out << "VALUES (" << values << ");\n";
             progress->increment();
         }
+        query.finish();
         out << "\n";
     }
     file->close();


### PR DESCRIPTION
This pull request includes an improvement to the `DbExport::exportDataToFile` method in `src/dbexport.cpp` to enhance the efficiency of database queries during data export.

Performance enhancement:

* [`src/dbexport.cpp`](diffhunk://#diff-f2171b1ae50c0dce2751bf55522c166ee267b871b938b440412a70b18445580bR92-R101): Added `query.setForwardOnly(true)` to optimize memory usage during large data exports and ensure the query is finished with `query.finish()` after processing.