### PR TITLE
Prompt for CSV delimeter

### DIFF
--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -35,6 +35,8 @@ qt_add_executable(SQLiteQueryAnalyzer WIN32 MACOSX_BUNDLE
         ../database/dbexportdata.cpp
         ../database/dbexportdata.h
         ../database/progress.h
+        ../ui/prompts.cpp
+        ../ui/prompts.h
 )
 target_link_libraries(SQLiteQueryAnalyzer PRIVATE
         Qt::Core

--- a/src/project/SQLiteAnalyzer.pro
+++ b/src/project/SQLiteAnalyzer.pro
@@ -28,7 +28,8 @@ SOURCES += \
     ../database/dbexport.cpp \
     ../database/dbexportschema.cpp \
     ../database/dbexportdata.cpp \
-    ../threading/cancellation.cpp
+    ../threading/cancellation.cpp \
+    ../ui/prompts.cpp \
 
 HEADERS += \
     ../ui/mainwindow.h \
@@ -45,6 +46,7 @@ HEADERS += \
     ../database/dbexportdata.h \
     ../threading/cancellation.h \
     ../threading/mainthread.h \
-    ../database/progress.h
+    ../database/progress.h \
+    ../ui/prompts.h
 
 FORMS    += ../ui/mainwindow.ui

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -344,7 +344,8 @@ void MainWindow::scriptSchema() const {
 void MainWindow::setEnabledActions(const bool enabled) {
     ui->actionRefresh->setEnabled(enabled);
     ui->actionShrink->setEnabled(enabled);
-    ui->menuScript_Data->setVisible(enabled);
+    ui->actionScript_CSV->setEnabled(enabled);
+    ui->actionScript_SQL->setEnabled(enabled);
     ui->actionExecute_Query->setEnabled(enabled);
     ui->actionScript_Schema->setEnabled(enabled);
     ui->actionCancel->setVisible(!enabled);

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -87,8 +87,6 @@ private:
     std::unique_ptr<CancellationTokenSource> tcs;
     bool loaded;
 
-    QString showFileDialog(QFileDialog::AcceptMode mode);
-
     void analyzeDatabase() const;
 
     void saveSession() const;

--- a/src/ui/prompts.cpp
+++ b/src/ui/prompts.cpp
@@ -1,0 +1,64 @@
+#include "prompts.h"
+
+#include <QFileDialog>
+#include <QInputDialog>
+
+#include "../settings/settings.h"
+
+QString Prompts::getCsvDelimiter(QWidget *parent,
+                                 [[maybe_unused]] const QString &defaultDelimiter = ",") {
+    bool ok{};
+    auto input = QInputDialog::getText(parent,
+                                       "CSV Delimeter",
+                                       "Please enter delimeter to use",
+                                       QLineEdit::Normal,
+                                       ",",
+                                       &ok);
+    if (!ok || input.isEmpty()) {
+        input = ",";
+    }
+    return input;
+}
+
+QString Prompts::getFolderPath(QWidget *parent) {
+    SessionState state;
+    Settings::getSessionState(&state);
+    auto directory = state.lastUsedExportPath;
+    if (state.lastUsedExportPath == Q_NULLPTR || state.lastUsedExportPath.isEmpty()) {
+        directory = QDir::home().absolutePath();
+    }
+
+    const auto outputFolder =
+            QFileDialog::getExistingDirectory(parent,
+                                              "Select output folder",
+                                              directory);
+    return outputFolder;
+}
+
+QString Prompts::getFilePath(QWidget *parent,
+                             const QFileDialog::AcceptMode mode) {
+    SessionState state;
+    Settings::getSessionState(&state);
+    auto directory = state.lastUsedExportPath;
+    if (state.lastUsedExportPath == Q_NULLPTR || state.lastUsedExportPath.isEmpty()) {
+        directory = QDir::home().absolutePath();
+    }
+
+    QFileDialog dialog(parent);
+    dialog.setAcceptMode(mode);
+    dialog.setDirectory(directory);
+    dialog.setFileMode(QFileDialog::AnyFile);
+    dialog.setViewMode(QFileDialog::Detail);
+
+    if (dialog.exec()) {
+        if (QStringList files = dialog.selectedFiles(); !files.empty()) {
+            const auto &filepath = files.first();
+            const auto folder = QFileInfo(filepath).absolutePath();
+            Settings::setLastUsedExportPath(folder);
+            return filepath;
+        }
+    }
+
+    qDebug("File dialog cancelled");
+    return Q_NULLPTR;
+}

--- a/src/ui/prompts.h
+++ b/src/ui/prompts.h
@@ -1,0 +1,15 @@
+#ifndef PRMOPTS_H
+#define PRMOPTS_H
+
+#include <QFileDialog>
+#include <QWidget>
+
+class Prompts {
+public:
+    static QString getCsvDelimiter(QWidget *, const QString &defaultDelimiter);
+    static QString getFolderPath(QWidget *parent);
+    static QString getFilePath(QWidget *parent, QFileDialog::AcceptMode mode);
+};
+
+
+#endif //PRMOPTS_H


### PR DESCRIPTION
This pull request introduces a new `Prompts` class to handle various UI prompts and refactors the `MainWindow` class to utilize this new class. Additionally, it updates the project files to include the new `prompts` files.

Refactoring and new class introduction:

* [`src/ui/mainwindow.cpp`](diffhunk://#diff-3de9409eb84cc560e65ddea18be24cb6092fb351183660fc96f48858d120e18fL229-R204): Refactored multiple methods (`createNewFile`, `openExistingFile`, `exportDataToSqlScript`, `exportDataToCsvFiles`, `saveSql`) to use the new `Prompts` class for file dialogs and CSV delimiter input. [[1]](diffhunk://#diff-3de9409eb84cc560e65ddea18be24cb6092fb351183660fc96f48858d120e18fL229-R204) [[2]](diffhunk://#diff-3de9409eb84cc560e65ddea18be24cb6092fb351183660fc96f48858d120e18fL275-R250) [[3]](diffhunk://#diff-3de9409eb84cc560e65ddea18be24cb6092fb351183660fc96f48858d120e18fL416-R392) [[4]](diffhunk://#diff-3de9409eb84cc560e65ddea18be24cb6092fb351183660fc96f48858d120e18fR428) [[5]](diffhunk://#diff-3de9409eb84cc560e65ddea18be24cb6092fb351183660fc96f48858d120e18fL490-R467)
* [`src/ui/prompts.cpp`](diffhunk://#diff-2e4cd136342058192aa895921bde1a253dca88daf62a84d60d2c663d781f44e7R1-R64): Added a new `Prompts` class with methods `getCsvDelimiter`, `getFolderPath`, and `getFilePath` to handle UI prompts.
* [`src/ui/prompts.h`](diffhunk://#diff-84ac59874beabef96ebc5711e4608e8ac24bfc0f87697e304b91e0bd700ae70aR1-R15): Added header file for the `Prompts` class.

Project file updates:

* [`src/project/CMakeLists.txt`](diffhunk://#diff-d0b751957f9fb4c59680d6ce93db372b62d73a014e7986575db3ba0b1aff67ccR38-R39): Included the new `prompts.cpp` and `prompts.h` files.
* [`src/project/SQLiteAnalyzer.pro`](diffhunk://#diff-4580a0f4efdc0c0757949c878e80735e09bd0afe6f6ceb93f44fa19433dff663L31-R32): Updated `SOURCES` and `HEADERS` to include the new `prompts` files. [[1]](diffhunk://#diff-4580a0f4efdc0c0757949c878e80735e09bd0afe6f6ceb93f44fa19433dff663L31-R32) [[2]](diffhunk://#diff-4580a0f4efdc0c0757949c878e80735e09bd0afe6f6ceb93f44fa19433dff663L48-R50)

Code cleanup:

* [`src/ui/mainwindow.cpp`](diffhunk://#diff-3de9409eb84cc560e65ddea18be24cb6092fb351183660fc96f48858d120e18fL194-L220): Removed the `showFileDialog` method from `MainWindow` as it is now handled by `Prompts`.
* [`src/ui/mainwindow.h`](diffhunk://#diff-5802ebe50e7f7e43ac965c6078f7c35d5978d46b02d34cd9d796043281734c8eL90-L91): Removed the declaration of the `showFileDialog` method.