### PR TITLE
Use Prompts everywhere

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -409,17 +409,7 @@ void MainWindow::exportDataToSqlScript() {
 }
 
 void MainWindow::exportDataToCsvFiles() {
-    SessionState state;
-    Settings::getSessionState(&state);
-    auto directory = state.lastUsedExportPath;
-    if (state.lastUsedExportPath == Q_NULLPTR || state.lastUsedExportPath.isEmpty()) {
-        directory = QDir::home().absolutePath();
-    }
-
-    const auto outputFolder =
-            QFileDialog::getExistingDirectory(this,
-                                              R"(Select output folder)",
-                                              directory);
+    const auto outputFolder = Prompts::getFolderPath(this);
     if (outputFolder.isEmpty()) {
         return;
     }

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -2,16 +2,14 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
-#include <QFileDialog>
-#include <qfuturewatcher.h>
 
 #include "../threading/cancellation.h"
 #include "../database/dbanalyzer.h"
 #include "../database/dbexport.h"
 #include "../database/dbexportdata.h"
 #include "../database/dbquery.h"
-#include "highlighter.h"
 #include "../database/dbtree.h"
+#include "highlighter.h"
 
 namespace Ui {
     class MainWindow;
@@ -51,7 +49,8 @@ public slots:
     void showExportDataProgress(const ExportDataProgress *progress,
                                 CancellationToken cancellationToken) const;
 
-    void exportDataAsync(const QString &filepath, const DatabaseInfo &info,
+    void exportDataAsync(const QString &filepath,
+                         const DatabaseInfo &info,
                          std::unique_ptr<ExportDataProgress>::pointer progress,
                          CancellationToken cancellationToken);
 


### PR DESCRIPTION
This pull request includes changes to the `src/ui/mainwindow.cpp` and `src/ui/mainwindow.h` files to refactor the code for better readability and maintainability. The most important changes include refactoring the `exportDataToCsvFiles` function, updating include directives, and formatting method parameters.

Refactoring for better readability and maintainability:

* [`src/ui/mainwindow.cpp`](diffhunk://#diff-3de9409eb84cc560e65ddea18be24cb6092fb351183660fc96f48858d120e18fL412-R412): Refactored `exportDataToCsvFiles` function to use the `Prompts::getFolderPath` method for selecting the output folder, simplifying the code and removing redundant checks.

Code cleanup:

* [`src/ui/mainwindow.h`](diffhunk://#diff-5802ebe50e7f7e43ac965c6078f7c35d5978d46b02d34cd9d796043281734c8eL5-R12): Removed unnecessary include directives (`QFileDialog` and `qfuturewatcher.h`) and adjusted the order of the remaining includes for consistency.
* [`src/ui/mainwindow.h`](diffhunk://#diff-5802ebe50e7f7e43ac965c6078f7c35d5978d46b02d34cd9d796043281734c8eL54-R53): Reformatted the `exportDataAsync` method parameters for better readability.