### PR TITLE
Exclude vc_redist.x64.exe from build artifacts

### DIFF
--- a/.github/workflows/windows-template.yml
+++ b/.github/workflows/windows-template.yml
@@ -69,10 +69,15 @@ jobs:
       - name: Build
         working-directory: ${{ github.workspace }}\src\project
         run: |          
-          cmake . -DCMAKE_PREFIX_PATH=${{ runner.temp }}\Qt\6.8.2\msvc2022_64 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /permissive-" -B build
+          cmake . `
+            -DCMAKE_PREFIX_PATH=${{ runner.temp }}\Qt\6.8.2\msvc2022_64 `
+            -DCMAKE_CXX_STANDARD=17 `
+            -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /permissive-" `
+            -B build
           cmake --build build --config Release
           ${{ runner.temp }}\Qt\6.8.2\msvc2022_64\bin\windeployqt.exe .\build\Release\SQLiteQueryAnalyzer.exe
-              
+          rm .\build\Release\vc_redist.x64.exe
+
       - name: Zip build
         working-directory: ${{ runner.temp }}
         run: |

--- a/.github/workflows/windows-template.yml
+++ b/.github/workflows/windows-template.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Build
         working-directory: ${{ github.workspace }}\src\project
+        shell: pwsh
         run: |          
           cmake . `
             -DCMAKE_PREFIX_PATH=${{ runner.temp }}\Qt\6.8.2\msvc2022_64 `


### PR DESCRIPTION
This pull request includes changes to the `jobs:` section in the `.github/workflows/windows-template.yml` file to improve the readability and functionality of the build script.

Improvements to the build script:

* `jobs:` in `.github/workflows/windows-template.yml`: Reformatted the `cmake` command for better readability by using backticks for line continuation.
* `jobs:` in `.github/workflows/windows-template.yml`: Added a command to remove `vc_redist.x64.exe` after the build process to clean up the build directory.