### PR TITLE
MacOS Intel Support

### DIFF
--- a/.github/workflows/macos-template.yml
+++ b/.github/workflows/macos-template.yml
@@ -7,13 +7,21 @@ on:
         description: 'Version number for the build'
         required: true
         type: string
+      os:
+        description: build agent
+        required: true
+        type: string
+      architecture:
+        description: cpu architecture
+        required: true
+        type: string
 
 jobs:
   template:
-    runs-on: macos-latest
+    runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v4
-
+ 
       - name: Update Version Number (Qt Project)
         shell: pwsh
         run: |
@@ -46,6 +54,6 @@ jobs:
       - name: Publish artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: SQLiteQuerAnalyzer_MacOS_v${{ inputs.version }}
+          name: SQLiteQuerAnalyzer_MacOS_v${{ inputs.version }}_${{ inputs.architecture }}
           path: |
             src/project/SQLiteQueryAnalyzer.dmg

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,16 @@ on:
       - '*'
 
 jobs:
-  build:
+  macos-arm64:
     uses: ./.github/workflows/macos-template.yml
     with:
       version: '0.2.${{ github.run_number }}'
+      os: 'macos-latest'
+      architecture: 'arm64'
+     
+  macos-intel:
+    uses: ./.github/workflows/macos-template.yml
+    with:
+      version: '0.2.${{ github.run_number }}'
+      os: 'macos-13'
+      architecture: 'intel'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,18 @@ env:
   VERSION: '0.2.${{ github.run_number }}'
 
 jobs:
-  macos:
+  macos-arm64:
     uses: ./.github/workflows/macos-template.yml
     with:
-      version: '0.2.${{ github.run_number }}'      
+      version: '0.2.${{ github.run_number }}'
+      os: macos-latest
+      architecture: arm64
+  macos-intel:
+    uses: ./.github/workflows/macos-template.yml
+    with:
+      version: '0.2.${{ github.run_number }}'
+      os: macos-13
+      architecture: intel
   windows:
     uses: ./.github/workflows/windows-template.yml
     with:
@@ -25,7 +33,8 @@ jobs:
     secrets: inherit
   release:
     needs: [
-      macos, 
+      macos-arm64,
+      macos-intel,
       windows
     ]
     runs-on: ubuntu-latest
@@ -72,12 +81,21 @@ jobs:
           asset_path: artifacts/SQLiteQuerAnalyzer_Windows_v${{ env.VERSION }}/SQLiteQueryAnalyzer_Windows.zip
           asset_name: SQLiteQuerAnalyzer for Windows (Binaries) v${{ env.VERSION }}.zip
           asset_content_type: application/zip
-      - name: Upload MacOS disk image
+      - name: Upload MacOS (ARM64) disk image
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: artifacts/SQLiteQuerAnalyzer_MacOS_v${{ env.VERSION }}/SQLiteQueryAnalyzer.dmg
-          asset_name: SQLiteQuerAnalyzer for MacOS v${{ env.VERSION }}.dmg
+          asset_path: artifacts/SQLiteQuerAnalyzer_MacOS_v${{ env.VERSION }}_arm64/SQLiteQueryAnalyzer.dmg
+          asset_name: SQLiteQuerAnalyzer for MacOS (ARM64) v${{ env.VERSION }}.dmg
+          asset_content_type: application/zip
+      - name: Upload MacOS (Intel) disk image
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: artifacts/SQLiteQuerAnalyzer_MacOS_v${{ env.VERSION }}_intel/SQLiteQueryAnalyzer.dmg
+          asset_name: SQLiteQuerAnalyzer for MacOS (Intel) v${{ env.VERSION }}.dmg
           asset_content_type: application/zip


### PR DESCRIPTION
This pull request adds support for building and releasing separate artifacts for different macOS architectures (ARM64 and Intel). The changes primarily involve modifying GitHub Actions workflows to handle the new architecture-specific builds and uploads.

### Workflow Modifications:

* [`.github/workflows/macos-template.yml`](diffhunk://#diff-8267cf5c7451772cab1c8ac2c6b1abdb1af1af24d4ba4668734251f3a1006c92R10-R21): Added inputs for `os` and `architecture` to allow specifying the build agent and CPU architecture. The `runs-on` property and artifact naming were updated to use these inputs. [[1]](diffhunk://#diff-8267cf5c7451772cab1c8ac2c6b1abdb1af1af24d4ba4668734251f3a1006c92R10-R21) [[2]](diffhunk://#diff-8267cf5c7451772cab1c8ac2c6b1abdb1af1af24d4ba4668734251f3a1006c92L49-R57)

* [`.github/workflows/macos.yml`](diffhunk://#diff-7b74d73de878e0e53f6768bbf3a3d4b50c3c6f1f16f9b64518690028b8206b1cL17-R29): Updated to include separate jobs for `macos-arm64` and `macos-intel`, each using the updated macOS template workflow with the appropriate `os` and `architecture` inputs.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L16-R27): Updated to include separate jobs for `macos-arm64` and `macos-intel`, using the updated macOS template workflow with the appropriate `os` and `architecture` inputs. The release job was modified to upload separate disk images for ARM64 and Intel architectures. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L16-R27) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L28-R37) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L75-R100)