### PR TITLE
Keyboard Shortcuts for switching between Editor and Tree

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -51,6 +51,14 @@ MainWindow::~MainWindow() {
     this->tree->clear();
 }
 
+void MainWindow::keyPressEvent(QKeyEvent *event){
+    auto const keys = event->keyCombination();
+    auto const modifers= keys.keyboardModifiers();
+    if (keys.key() == Qt::Key_T && modifers == Qt::ControlModifier) {
+        ui->treeWidget->setFocus();
+    }
+}
+
 void MainWindow::connectSignalSlots() const {
     connect(ui->actionNew,
             SIGNAL(triggered()),

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -53,13 +53,13 @@ MainWindow::~MainWindow() {
 
 void MainWindow::keyPressEvent(QKeyEvent *event){
     auto const keys = event->keyCombination();
-    auto const modifers= keys.keyboardModifiers();
-    if (keys.key() == Qt::Key_T && modifers == Qt::ControlModifier) {
+    auto const modifiers = keys.keyboardModifiers();
+    if (keys.key() == Qt::Key_T && modifiers == Qt::ControlModifier) {
         ui->treeWidget->setFocus();
-    } else if (keys.key() == Qt::Key_E && modifers == Qt::ControlModifier) {
+    } else if (keys.key() == Qt::Key_E && modifiers == Qt::ControlModifier) {
         ui->tabWidget->setCurrentIndex(-1);
         ui->textEdit->setFocus();
-    } else if (keys.key() == Qt::Key_Q && modifers == Qt::ControlModifier) {
+    } else if (keys.key() == Qt::Key_Q && modifiers == Qt::ControlModifier) {
         this->appExit();
     }
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -59,6 +59,8 @@ void MainWindow::keyPressEvent(QKeyEvent *event){
     } else if (keys.key() == Qt::Key_E && modifers == Qt::ControlModifier) {
         ui->tabWidget->setCurrentIndex(-1);
         ui->textEdit->setFocus();
+    } else if (keys.key() == Qt::Key_Q && modifers == Qt::ControlModifier) {
+        this->appExit();
     }
 }
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -56,6 +56,9 @@ void MainWindow::keyPressEvent(QKeyEvent *event){
     auto const modifers= keys.keyboardModifiers();
     if (keys.key() == Qt::Key_T && modifers == Qt::ControlModifier) {
         ui->treeWidget->setFocus();
+    } else if (keys.key() == Qt::Key_E && modifers == Qt::ControlModifier) {
+        ui->tabWidget->setCurrentIndex(-1);
+        ui->textEdit->setFocus();
     }
 }
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -23,6 +23,8 @@ public:
 
     ~MainWindow() override;
 
+    void keyPressEvent(QKeyEvent *event) override;
+
     void connectSignalSlots() const;
 
     void resizeEvent(QResizeEvent *e) override;


### PR DESCRIPTION
This pull request introduces a new feature to handle specific key press events in the `MainWindow` class within the GUI application. The most important changes include adding a new method to handle key press events and updating the class definition to accommodate this new method.

New feature for handling key press events:

* [`src/gui/mainwindow.cpp`](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eR54-R66): Added the `keyPressEvent` method to handle Ctrl+T, Ctrl+E, and Ctrl+Q key combinations for focusing on the tree widget, switching to the text edit widget, and exiting the application, respectively.
* [`src/gui/mainwindow.h`](diffhunk://#diff-2766666e5fe5f1555760b768c15f4866d3c80b04d3a401b73e9e391a547313f3R26-R27): Updated the `MainWindow` class definition to include the `keyPressEvent` method.