### PR TITLE
Fix Table Data Memory Leak

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -502,11 +502,8 @@ void MainWindow::treeNodeChanged(QTreeWidgetItem *item,
             return;
         }
 
-        if (ui->tableView->model() != Q_NULLPTR)
-            std::make_unique<QSqlTableModel>(ui->tableView->model());
-
-        // The model is no longer alive after the unique pointer destroys it...
         // ReSharper disable once CppDFAMemoryLeak
+        delete ui->tableView->model();
         const auto model = new QSqlTableModel(nullptr,
                                               this->database->getDatabase());
         model->setTable(item->text(column));


### PR DESCRIPTION
This pull request includes a significant change to the `void MainWindow::treeNodeChanged(QTreeWidgetItem *item,` function in the `src/gui/mainwindow.cpp` file. The primary modification involves replacing the use of `std::make_unique` with a direct deletion of the `QSqlTableModel` object.

### Codebase simplification:

* [`src/gui/mainwindow.cpp`](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL505-R506): Removed the use of `std::make_unique` for the `QSqlTableModel` and directly deleted the model using `delete ui->tableView->model()`. This change simplifies the memory management of the model by ensuring it is properly deleted before creating a new instance.