### PR TITLE
Update MacOS recommended build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ cmake --build . --config Release
 
 ### Building on MacOS
 
-Install CMAke and Qt6. It's recommended to install Qt using the [official installer](https://www.qt.io/download-qt-installer-oss)
-
+Install CMake and Qt6. It's recommended to install Qt using the [official installer](https://www.qt.io/download-qt-installer-oss)
 ```sh
 brew update
 brew install cmake

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ cmake --build . --config Release
 
 ### Building on MacOS
 
-Install CMAke and Qt6
+Install CMAke and Qt6. It's recommended to install Qt using the [official installer](https://www.qt.io/download-qt-installer-oss)
 
 ```sh
 brew update
@@ -115,7 +115,9 @@ cmake .
 cmake --build . --config Release
 ```
 
-Build MacOS disk image (Optional)
+Build MacOS disk image (Optional). 
+
+There is a bug in the Homebrew distribution of Qt which causes the use of `macdeployqt` to fail.
 
 ```sh
 macdeployqt SQLiteQueryAnalyzer.app -dmg


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to provide additional guidance on installing Qt and to address a known issue with the Homebrew distribution of Qt.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-R102): Added a recommendation to install Qt using the [official installer](https://www.qt.io/download-qt-installer-oss).
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L118-R120): Added a note about a bug in the Homebrew distribution of Qt that causes the use of `macdeployqt` to fail.