### PR TITLE
CTRL+D to set focus to Table Data

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -57,8 +57,11 @@ void MainWindow::keyPressEvent(QKeyEvent *event) {
     if (keys.key() == Qt::Key_T && modifiers == Qt::ControlModifier) {
         ui->treeWidget->setFocus();
     } else if (keys.key() == Qt::Key_E && modifiers == Qt::ControlModifier) {
-        ui->tabWidget->setCurrentIndex(-1);
+        ui->tabWidget->setCurrentIndex(0);
         ui->textEdit->setFocus();
+    } else if (keys.key() == Qt::Key_D && modifiers == Qt::ControlModifier) {
+        ui->tabWidget->setCurrentIndex(1);
+        ui->tableView->setFocus();
     } else if (keys.key() == Qt::Key_Q && modifiers == Qt::ControlModifier) {
         this->appExit();
     }


### PR DESCRIPTION
This pull request includes changes to the keyboard event handling in the `MainWindow` class to improve user navigation within the application. The most important changes include modifying the behavior of existing keyboard shortcuts and adding a new shortcut.

Keyboard event handling improvements:

* [`src/gui/mainwindow.cpp`](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL60-R64): Changed the behavior of the `Ctrl+E` shortcut to set the current tab index to `0` instead of `-1` and focus on `textEdit`.
* [`src/gui/mainwindow.cpp`](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL60-R64): Added a new keyboard shortcut `Ctrl+D` to switch to the second tab and focus on `tableView`.