### PR TITLE
Hide internal SQLite tables from tree

### DIFF
--- a/src/database/dbanalyzer.cpp
+++ b/src/database/dbanalyzer.cpp
@@ -35,7 +35,7 @@ void DbAnalyzer::loadTables(DatabaseInfo &info) const {
     while (query.next()) {
         Table table;
         table.name = query.value("name").toString();
-        if (table.name == "sqlite_sequence") {
+        if (table.name == "sqlite_sequence" || table.name == "sqlite_stat1") {
             continue;
         }
         info.tables.append(table);

--- a/src/database/dbanalyzer.cpp
+++ b/src/database/dbanalyzer.cpp
@@ -35,6 +35,9 @@ void DbAnalyzer::loadTables(DatabaseInfo &info) const {
     while (query.next()) {
         Table table;
         table.name = query.value("name").toString();
+        if (table.name == "sqlite_sequence") {
+            continue;
+        }
         info.tables.append(table);
         qDebug() << table.name;
     }


### PR DESCRIPTION
This pull request includes a change to the `DbAnalyzer::loadTables` method in the `src/database/dbanalyzer.cpp` file. The change adds a condition to skip certain internal SQLite tables during the table loading process.

* [`src/database/dbanalyzer.cpp`](diffhunk://#diff-115a212d04d8ce5c5e68c2588e2a4159b3d4bf871c52a7c380e8d7c2a7b35966R38-R40): Added a condition to skip the `sqlite_sequence` and `sqlite_stat1` tables in the `DbAnalyzer::loadTables` method.