### PR TITLE
Qt 6.9.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,10 @@
     "features": {
 	      "ghcr.io/devcontainers/features/powershell:1": {}
     },
-    "postCreateCommand": "sudo apt-get update && sudo apt-get install -y python3 python3-pip && sudo apt install -y libglx-dev libgl1-mesa-dev libxkbcommon-x11-dev libfontconfig1 libdbus-1-dev && pip install aqtinstall --break-system-packages && aqt install-qt linux desktop 6.8.2",
+    "postCreateCommand": "sudo apt-get update && sudo apt-get install -y python3 python3-pip && sudo apt install -y libglx-dev libgl1-mesa-dev libxkbcommon-x11-dev libfontconfig1 libdbus-1-dev && pip install aqtinstall --break-system-packages && aqt install-qt linux desktop 6.9.0",
     "remoteUser": "vscode",
     "remoteEnv": {
-        "QT_DIR": "/workspaces/sqlitequery/6.8.2/gcc_64",
-        "Qt6_DIR": "/workspaces/sqlitequery/6.8.2/gcc_64"
+        "QT_DIR": "/workspaces/sqlitequery/6.9.0/gcc_64",
+        "Qt6_DIR": "/workspaces/sqlitequery/6.9.0/gcc_64"
     }
 }

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.2'
+        version: '6.9.0'
     - name: QMake
       run: qmake
       working-directory: src/project

--- a/.github/workflows/macos-template.yml
+++ b/.github/workflows/macos-template.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.8.2'
+          version: '6.9.0'
 
       - name: QMake
         run: qmake

--- a/.github/workflows/windows-template.yml
+++ b/.github/workflows/windows-template.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.8.2'
+          version: '6.9.0'
           host: windows
           target: desktop
           arch: win64_msvc2022_64
@@ -71,12 +71,12 @@ jobs:
         shell: pwsh
         run: |          
           cmake . `
-            -DCMAKE_PREFIX_PATH=${{ runner.temp }}\Qt\6.8.2\msvc2022_64 `
+            -DCMAKE_PREFIX_PATH=${{ runner.temp }}\Qt\6.9.0\msvc2022_64 `
             -DCMAKE_CXX_STANDARD=17 `
             -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /permissive-" `
             -B build
           cmake --build build --config Release
-          ${{ runner.temp }}\Qt\6.8.2\msvc2022_64\bin\windeployqt.exe .\build\Release\SQLiteQueryAnalyzer.exe
+          ${{ runner.temp }}\Qt\6.9.0\msvc2022_64\bin\windeployqt.exe .\build\Release\SQLiteQueryAnalyzer.exe
           rm .\build\Release\vc_redist.x64.exe
 
       - name: Zip build

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,5 @@ src/project/cmake-build-debug
 src/project/artifacts/SQLiteQueryAnalyzer-Setup.exe
 src/.vs
 *.nupkg
-6.8.2
+6.9.0
 *aqtinstall.log

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Here are some screenshots of SQLite Query Analyzer in action:
 ### Prerequisites
 
 - CMake 3.16 or later - Install from [official website](https://cmake.org/download/)
-- Qt 6.8.2 - Install from [official website](https://www.qt.io/download-qt-installer-oss)
+- Qt 6.9.0 - Install from [official website](https://www.qt.io/download-qt-installer-oss)
 - Git
 - [Powershell Core](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) (Optional)
 
@@ -128,9 +128,9 @@ Build the project (These instructions assumes that Qt root folder is C:\Qt)
 
 ```pwsh
 cd src
-cmake . -DCMAKE_PREFIX_PATH=C:/Qt/6.8.2/msvc2022_64 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /permissive-" -B build
+cmake . -DCMAKE_PREFIX_PATH=C:/Qt/6.9.0/msvc2022_64 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /permissive-" -B build
 cmake --build build --config Release
-C:\Qt\6.8.2\msvc2022_64\bin\windeployqt.exe .\build\Release\SQLiteQueryAnalyzer.exe
+C:\Qt\6.9.0\msvc2022_64\bin\windeployqt.exe .\build\Release\SQLiteQueryAnalyzer.exe
 ```
 
 Build the installer project using Inno Setup (Optional)

--- a/src/project/build.ps1
+++ b/src/project/build.ps1
@@ -1,7 +1,7 @@
 if ($IsWindows) {
-    cmake . -DCMAKE_PREFIX_PATH=C:/Qt/6.8.2/msvc2022_64 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /permissive-" -B build
+    cmake . -DCMAKE_PREFIX_PATH=C:/Qt/6.9.0/msvc2022_64 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS="/Zc:__cplusplus /permissive-" -B build
     cmake --build build --config Release --parallel 32
-    C:\Qt\6.8.2\msvc2022_64\bin\windeployqt.exe .\build\Release\SQLiteQueryAnalyzer.exe
+    C:\Qt\6.9.0\msvc2022_64\bin\windeployqt.exe .\build\Release\SQLiteQueryAnalyzer.exe
     ../../deps/innosetup/ISCC.exe setup.iss
 } 
 


### PR DESCRIPTION
This pull request updates the project to use Qt version 6.9.0 instead of 6.8.2 across various configuration files, build scripts, and documentation. The changes ensure consistency in the Qt version used for development, CI workflows, and user instructions.

### Updates to Qt Version:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L7-R11): Updated `postCreateCommand` and environment variables `QT_DIR` and `Qt6_DIR` to reference Qt 6.9.0.
* [`.github/workflows/linux.yml`](diffhunk://#diff-21364b2e6fae1f2875cee1ab3daefb0685403687eaf8bc32b5c6eacda351c9d3L33-R33): Changed the Qt version installed in the CI workflow to 6.9.0.
* [`.github/workflows/macos-template.yml`](diffhunk://#diff-8267cf5c7451772cab1c8ac2c6b1abdb1af1af24d4ba4668734251f3a1006c92L40-R40): Updated the Qt version in the macOS CI workflow to 6.9.0.
* [`.github/workflows/windows-template.yml`](diffhunk://#diff-66dfd9e333e15cf91fdd96215470da0b24e7033166c69b634120421b5fe010b1L43-R43): Adjusted the Qt version in the Windows CI workflow, including `CMAKE_PREFIX_PATH` and `windeployqt` references, to 6.9.0. [[1]](diffhunk://#diff-66dfd9e333e15cf91fdd96215470da0b24e7033166c69b634120421b5fe010b1L43-R43) [[2]](diffhunk://#diff-66dfd9e333e15cf91fdd96215470da0b24e7033166c69b634120421b5fe010b1L74-R79)

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R65): Updated references to Qt 6.9.0 in the prerequisites and build instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R65) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L131-R133)

### Build Script Updates:

* [`src/project/build.ps1`](diffhunk://#diff-3de23a5a48e2c382cd3171ccf8f406735f8588df45aeb0af436822b521fbf0ddL2-R4): Updated `CMAKE_PREFIX_PATH` and `windeployqt` paths to use Qt 6.9.0.