### PR TITLE
Fix memory leak when switching databases

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -249,8 +249,10 @@ void MainWindow::openDatabase(const QString &filename) {
     ui->textEdit->clear();
 
     if (ui->tableView->model() != Q_NULLPTR) {
-        std::make_unique<QSqlTableModel>(ui->tableView->model());
+        const auto model = dynamic_cast<QSqlTableModel*>(ui->tableView->model());
+        model->clear();
         ui->tableView->setModel(Q_NULLPTR);
+        delete model;
     }
 
     this->setWindowTitle("SQLite Query Analyzer - " + filename);


### PR DESCRIPTION
This pull request includes a fix to the `openDatabase` method in `src/gui/mainwindow.cpp` to properly handle the cleanup of the table view's model. The most important change ensures safe casting and cleanup of the existing model to prevent memory leaks.

### Memory management improvements:
* [`src/gui/mainwindow.cpp`](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL252-R255): Replaced the incorrect use of `std::make_unique` with a `dynamic_cast` to safely cast the existing model to `QSqlTableModel*`, added a `clear()` call to reset the model's data, and explicitly deleted the model after setting it to `nullptr` to ensure proper memory cleanup.