### PR TITLE
Show status and error messages in status bar

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -495,7 +495,6 @@ void MainWindow::treeNodeChanged(QTreeWidgetItem *item,
     if (this->dataExportProgress.get() != nullptr) {
         const auto msg = "Unable to process request. Data export in progress - " + 
             QString("%1 row(s)").arg(this->dataExportProgress.get()->getAffectedRows());
-        ui->queryResultMessagesTextEdit->setPlainText(msg);
         this->showMessage(msg);
         ui->queryResultTab->setCurrentIndex(1);
         return;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -215,8 +215,8 @@ void MainWindow::saveSession() const {
 
 void MainWindow::createNewFile() {
     if (this->dataExportProgress.get() != nullptr) {
-        ui->queryResultMessagesTextEdit->setPlainText(
-            "Unable to process request. Data export in progress");
+        const auto msg = "Unable to process request. Data export in progress";
+        this->statusBar->showMessage(msg, 5000);
         ui->queryResultTab->setCurrentIndex(1);
         return;
     }
@@ -229,8 +229,8 @@ void MainWindow::createNewFile() {
 
 void MainWindow::openDatabase(const QString &filename) {
     if (this->dataExportProgress.get() != nullptr) {
-        ui->queryResultMessagesTextEdit->setPlainText(
-            "Unable to process request. Data export in progress");
+        const auto msg = "Unable to process request. Data export in progress";
+        this->statusBar->showMessage(msg, 5000);
         ui->queryResultTab->setCurrentIndex(1);
         return;
     }
@@ -264,8 +264,8 @@ void MainWindow::openDatabase(const QString &filename) {
 
 void MainWindow::openExistingFile() {
     if (this->dataExportProgress.get() != nullptr) {
-        ui->queryResultMessagesTextEdit->setPlainText(
-            "Unable to process request. Data export in progress");
+        const auto msg = "Unable to process request. Data export in progress";
+        this->statusBar->showMessage(msg, 5000);
         ui->queryResultTab->setCurrentIndex(1);
         return;
     }
@@ -283,8 +283,8 @@ void MainWindow::appExit() const {
 
 void MainWindow::shrink() const {
     if (this->dataExportProgress.get() != nullptr) {
-        ui->queryResultMessagesTextEdit->setPlainText(
-            "Unable to process request. Data export in progress");
+        const auto msg = "Unable to process request. Data export in progress";
+        this->statusBar->showMessage(msg, 5000);
         ui->queryResultTab->setCurrentIndex(1);
         return;
     }
@@ -302,8 +302,8 @@ void MainWindow::refreshDatabase() const {
 
 void MainWindow::analyzeDatabase() const {
     if (this->dataExportProgress.get() != nullptr) {
-        ui->queryResultMessagesTextEdit->setPlainText(
-            "Unable to process request. Data export in progress");
+        const auto msg = "Unable to process request. Data export in progress";
+        this->statusBar->showMessage(msg, 5000);
         ui->queryResultTab->setCurrentIndex(1);
         return;
     }
@@ -321,8 +321,8 @@ void MainWindow::analyzeDatabase() const {
 
 void MainWindow::executeQuery() const {
     if (this->dataExportProgress.get() != nullptr) {
-        ui->queryResultMessagesTextEdit->setPlainText(
-            "Unable to process request. Data export in progress");
+        const auto msg = "Unable to process request. Data export in progress";
+        this->statusBar->showMessage(msg, 5000);
         ui->queryResultTab->setCurrentIndex(1);
         return;
     }
@@ -340,8 +340,7 @@ void MainWindow::executeQuery() const {
 
     const auto milliseconds = static_cast<double>(time.elapsed());
     const auto msg = "Query execution took " + QString::number(milliseconds / 1000) + " seconds";
-    ui->queryResultMessagesTextEdit->setPlainText(msg);
-    this->statusBar->showMessage(msg, 5000);
+    this->showMessage(msg);
 
     foreach(const QString sql, list) {
         if (sql.contains("create", Qt::CaseInsensitive) ||
@@ -384,9 +383,7 @@ void MainWindow::showExportDataProgress(const ExportDataProgress *progress,
         do {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
             MainThread::run([this, progress]() {
-                const auto msg = QString("Exported %1 row(s)").arg(progress->getAffectedRows());
-                ui->queryResultMessagesTextEdit->setPlainText(msg);
-                this->statusBar->showMessage(msg, 5000);
+                this->showMessage(QString("Exported %1 row(s)").arg(progress->getAffectedRows()));
             });
         } while (!cancellationToken.isCancellationRequested() &&
                  !progress->isCompleted());
@@ -406,9 +403,7 @@ void MainWindow::exportDataAsync(const QString &filepath,
     future.then([this, progress] {
         MainThread::run([this, progress]() {
             this->setEnabledActions(true);
-            const auto msg = QString("Exported %1 row(s)").arg(progress->getAffectedRows());
-            ui->queryResultMessagesTextEdit->setPlainText(msg);
-            this->statusBar->showMessage(msg, 5000);
+            this->showMessage(QString("Exported %1 row(s)").arg(progress->getAffectedRows()));
         });
     });
 }
@@ -464,9 +459,7 @@ void MainWindow::exportDataToCsvFiles() {
     future.then([this, progress] {
         MainThread::run([this, progress]() {
             this->setEnabledActions(true);
-            const auto msg = QString("Exported %1 row(s)").arg(progress->getAffectedRows());
-            ui->queryResultMessagesTextEdit->setPlainText(msg);
-            this->statusBar->showMessage(msg, 5000);
+            this->showMessage(QString("Exported %1 row(s)").arg(progress->getAffectedRows()));
             ui->queryResultTab->setCurrentIndex(1);
         });
     });
@@ -500,10 +493,10 @@ void MainWindow::treeNodeChanged(QTreeWidgetItem *item) const {
 void MainWindow::treeNodeChanged(QTreeWidgetItem *item,
                                  const int column) const {
     if (this->dataExportProgress.get() != nullptr) {
-        ui->queryResultMessagesTextEdit->setPlainText(
-            "Unable to process request. Data export in progress - " + QString(
-                "%1 row(s)").arg(
-                this->dataExportProgress.get()->getAffectedRows()));
+        const auto msg = "Unable to process request. Data export in progress - " + 
+            QString("%1 row(s)").arg(this->dataExportProgress.get()->getAffectedRows());
+        ui->queryResultMessagesTextEdit->setPlainText(msg);
+        this->showMessage(msg);
         ui->queryResultTab->setCurrentIndex(1);
         return;
     }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include <QInputDialog>
 #include <QSqlTableModel>
 #include <QTreeWidget>
+#include <QStatusBar>
 #include <QTableView>
 #include <QtConcurrent/QtConcurrent>
 #include <chrono>
@@ -36,6 +37,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
 
     this->recentFilesMenu = std::make_unique<QMenu>("Recent Files");
     ui->menuFile->insertMenu(ui->actionSave, recentFilesMenu.get());
+
+    this->statusBar = std::make_unique<QStatusBar>(this);
+    this->setStatusBar(statusBar.get());
 
     Settings::init();
     this->loadRecentFiles();

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -545,3 +545,8 @@ void MainWindow::about() {
                          "for querying and manipulating SQLite databases.";
     QMessageBox::about(this, "About", text);
 }
+
+void MainWindow::showMessage(const QString &message) const {
+    ui->queryResultMessagesTextEdit->setPlainText(message);
+    this->statusBar->showMessage(message, 5000);
+}

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -384,8 +384,9 @@ void MainWindow::showExportDataProgress(const ExportDataProgress *progress,
         do {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
             MainThread::run([this, progress]() {
-                ui->queryResultMessagesTextEdit->setPlainText(
-                    QString("Exported %1 row(s)").arg(progress->getAffectedRows()));
+                const auto msg = QString("Exported %1 row(s)").arg(progress->getAffectedRows());
+                ui->queryResultMessagesTextEdit->setPlainText(msg);
+                this->statusBar->showMessage(msg, 5000);
             });
         } while (!cancellationToken.isCancellationRequested() &&
                  !progress->isCompleted());
@@ -405,8 +406,9 @@ void MainWindow::exportDataAsync(const QString &filepath,
     future.then([this, progress] {
         MainThread::run([this, progress]() {
             this->setEnabledActions(true);
-            ui->queryResultMessagesTextEdit->setPlainText(
-                QString("Exported %1 row(s)").arg(progress->getAffectedRows()));
+            const auto msg = QString("Exported %1 row(s)").arg(progress->getAffectedRows());
+            ui->queryResultMessagesTextEdit->setPlainText(msg);
+            this->statusBar->showMessage(msg, 5000);
         });
     });
 }
@@ -462,8 +464,10 @@ void MainWindow::exportDataToCsvFiles() {
     future.then([this, progress] {
         MainThread::run([this, progress]() {
             this->setEnabledActions(true);
-            ui->queryResultMessagesTextEdit->setPlainText(
-                QString("Exported %1 row(s)").arg(progress->getAffectedRows()));
+            const auto msg = QString("Exported %1 row(s)").arg(progress->getAffectedRows());
+            ui->queryResultMessagesTextEdit->setPlainText(msg);
+            this->statusBar->showMessage(msg, 5000);
+            ui->queryResultTab->setCurrentIndex(1);
         });
     });
     showExportDataProgress(progress, cancellationToken);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -339,9 +339,9 @@ void MainWindow::executeQuery() const {
     }
 
     const auto milliseconds = static_cast<double>(time.elapsed());
-    const auto msg = "Query execution took " + QString::number(
-                         milliseconds / 1000) + " seconds";
+    const auto msg = "Query execution took " + QString::number(milliseconds / 1000) + " seconds";
     ui->queryResultMessagesTextEdit->setPlainText(msg);
+    this->statusBar->showMessage(msg, 5000);
 
     foreach(const QString sql, list) {
         if (sql.contains("create", Qt::CaseInsensitive) ||

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -97,6 +97,8 @@ private:
     void saveWindowState(const QSize &size) const;
 
     void restoreWindowState();
+
+    void showMessage(const QString &message) const;
 };
 
 #endif // MAINWINDOW_H

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -2,6 +2,7 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include <QStatusBar>
 
 #include "../threading/cancellation.h"
 #include "../database/dbanalyzer.h"
@@ -79,6 +80,7 @@ public slots:
 private:
     std::unique_ptr<Ui::MainWindow> ui;
     std::unique_ptr<QMenu> recentFilesMenu;
+    std::unique_ptr<QStatusBar> statusBar;
     std::unique_ptr<Database> database;
     std::unique_ptr<DbAnalyzer> analyzer;
     std::unique_ptr<DbQuery> query;


### PR DESCRIPTION
This pull request introduces a `QStatusBar` to the `MainWindow` class, replacing the use of `QTextEdit` for displaying messages. It also centralizes message handling with a new `showMessage` method to improve code maintainability and user experience.

### Addition of `QStatusBar` for Message Display:
* Added a `QStatusBar` instance to `MainWindow`, initialized in the constructor, and set as the main window's status bar. (`src/gui/mainwindow.cpp`, [[1]](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eR14) [[2]](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eR41-R43); `src/gui/mainwindow.h`, [[3]](diffhunk://#diff-2766666e5fe5f1555760b768c15f4866d3c80b04d3a401b73e9e391a547313f3R5) [[4]](diffhunk://#diff-2766666e5fe5f1555760b768c15f4866d3c80b04d3a401b73e9e391a547313f3R83)

### Centralized Message Handling:
* Introduced a `showMessage` method in `MainWindow` to display messages in both the `QStatusBar` and the `QTextEdit`. This method is used throughout the codebase to replace repetitive message display logic. (`src/gui/mainwindow.cpp`, [[1]](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eR541-R545); `src/gui/mainwindow.h`, [[2]](diffhunk://#diff-2766666e5fe5f1555760b768c15f4866d3c80b04d3a401b73e9e391a547313f3R100-R101)

### Refactoring of Message Display Logic:
* Replaced direct calls to `setPlainText` on `QTextEdit` with calls to `showMessage` in various methods, ensuring consistent behavior and reducing code duplication:
  - `createNewFile`, `openDatabase`, `openExistingFile`, `shrink`, `refreshDatabase`, `analyzeDatabase`, and `executeQuery` methods now use `showMessage` for error messages when a data export is in progress. (`src/gui/mainwindow.cpp`, [[1]](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL214-R219) [[2]](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL228-R233) [[3]](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL263-R268) [[4]](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL282-R287) [[5]](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL301-R306) [[6]](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL320-R325)
  - Updated message display for query execution time and data export progress. (`src/gui/mainwindow.cpp`, [[1]](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL338-R343) [[2]](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL383-R386) [[3]](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL404-R406) [[4]](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL461-R463)
  - Enhanced message handling in `treeNodeChanged` to include both `QStatusBar` and `QTextEdit`. (`src/gui/mainwindow.cpp`, [src/gui/mainwindow.cppL495-R499](diffhunk://#diff-50b364e3b4577505a4662971abc19f01aed81ec7d910fd20fd22fb139c3d896eL495-R499))