### PR TITLE
Add FUNDING.yml to support various funding platforms

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,13 @@
+# These are supported funding model platforms
+
+github: christianhelle
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: christianhelle
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: christianhelle
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+custom: ["https://paypal.me/christianhelle", "https://buymeacoffee.com/christianhelle"]


### PR DESCRIPTION
This pull request adds a funding configuration file to the repository to specify supported funding platforms and provide links for financial contributions.

Funding configuration:

* [`.github/FUNDING.yml`](diffhunk://#diff-07985fdcade0e64d11482724879a644f07879ba61b8fb6c6119e1b1902b72ae4R1-R13): Added a new funding file that includes various funding platforms (e.g., GitHub, Ko-fi, Liberapay) and custom links for contributions via PayPal and Buy Me a Coffee.