### PR TITLE
Enable SSH daemon on Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,10 @@
     "name": "C++ Development with CMake and Qt",
     "image": "mcr.microsoft.com/devcontainers/cpp:ubuntu-24.04", // Base image
     "features": {
-	      "ghcr.io/devcontainers/features/powershell:1": {}
+        "ghcr.io/devcontainers/features/powershell:1": {},
+        "ghcr.io/devcontainers/features/sshd:1": {
+            "version": "latest"
+        }
     },
     "postCreateCommand": "sudo apt-get update && sudo apt-get install -y python3 python3-pip && sudo apt install -y libglx-dev libgl1-mesa-dev libxkbcommon-x11-dev libfontconfig1 libdbus-1-dev && pip install aqtinstall --break-system-packages && aqt install-qt linux desktop 6.9.0",
     "remoteUser": "vscode",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
         "ghcr.io/devcontainers/features/powershell:1": {},
         "ghcr.io/devcontainers/features/sshd:1.0.10": {}
     },
+    "forwardPorts": [22],
     "postCreateCommand": "sudo apt-get update && sudo apt-get install -y python3 python3-pip && sudo apt install -y libglx-dev libgl1-mesa-dev libxkbcommon-x11-dev libfontconfig1 libdbus-1-dev && pip install aqtinstall --break-system-packages && aqt install-qt linux desktop 6.9.0",
     "remoteUser": "vscode",
     "remoteEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,7 @@
     "image": "mcr.microsoft.com/devcontainers/cpp:ubuntu-24.04", // Base image
     "features": {
         "ghcr.io/devcontainers/features/powershell:1": {},
-        "ghcr.io/devcontainers/features/sshd:1": {
-            "version": "latest"
-        }
+        "ghcr.io/devcontainers/features/sshd:1.0.10": {}
     },
     "postCreateCommand": "sudo apt-get update && sudo apt-get install -y python3 python3-pip && sudo apt install -y libglx-dev libgl1-mesa-dev libxkbcommon-x11-dev libfontconfig1 libdbus-1-dev && pip install aqtinstall --break-system-packages && aqt install-qt linux desktop 6.9.0",
     "remoteUser": "vscode",


### PR DESCRIPTION
This pull request updates the development container configuration to enhance its functionality by adding support for SSH.

**Development environment updates:**

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L5-R8): Added the `ghcr.io/devcontainers/features/sshd:1` feature with the latest version to enable SSH support in the development container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated development container configuration to include SSH daemon support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->