### PR TITLE
Migrate macOS workflows from QMake to CMake

### DIFF
--- a/.github/workflows/macos-template.yml
+++ b/.github/workflows/macos-template.yml
@@ -44,8 +44,7 @@ jobs:
           cmake --install .
 
       - name: macdeployqt
-        working-directory: src
-        run: macdeployqt SQLiteQueryAnalyzer.app -dmg -appstore-compliant
+        run: macdeployqt install/SQLiteQueryAnalyzer.app -dmg -appstore-compliant
 
       - name: Publish artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macos-template.yml
+++ b/.github/workflows/macos-template.yml
@@ -37,13 +37,11 @@ jobs:
         with:
           version: "6.9.0"
 
-      - name: QMake
-        run: qmake
-        working-directory: src
-
-      - name: Make
-        run: make -j 32
-        working-directory: src
+      - name: CMake
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./install .
+          cmake --build . --config Release --parallel 32
+          cmake --install .
 
       - name: macdeployqt
         working-directory: src

--- a/.github/workflows/macos-template.yml
+++ b/.github/workflows/macos-template.yml
@@ -27,6 +27,8 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
+          $version = (Get-Content -Path CMakeLists.txt -Raw) -replace 'VERSION 1.0', "VERSION `"$env:VERSION`""
+          $version | Set-Content -Path CMakeLists.txt
           $version = (Get-Content -Path src/main.cpp -Raw) -replace 'constexpr auto Version = "1.0.0";', "constexpr auto Version = `"$env:VERSION`";"
           $version | Set-Content -Path src/main.cpp
 


### PR DESCRIPTION
Replace QMake + Make with CMake in the macOS workflow template, matching the Linux workflow pattern.